### PR TITLE
Modified start and stop to use a cp instead of mv

### DIFF
--- a/auto/install.sh
+++ b/auto/install.sh
@@ -59,8 +59,8 @@ echo - Moving Global Start/Stop Commands -
 cd ..
 cd imagecat
 cd auto
-mv start.sh ../../deploy
-mv stop.sh ../../deploy
+cp start.sh ../../deploy
+cp stop.sh ../../deploy
 cd ..
 cd ..
 cd deploy


### PR DESCRIPTION
When re-installing, the application was unable to locate the start.sh
and stop.sh files as they were moved. I propose leaving the original
files in position instead.
