### PR TITLE
Docker allow override of list file

### DIFF
--- a/DOCKER/Dockerfile
+++ b/DOCKER/Dockerfile
@@ -17,7 +17,7 @@ ENV JAVA_HOME=/usr/lib/jvm/java-7-openjdk-amd64
 ENV JRE_HOME=/usr/lib/jvm/java-7-openjdk-amd64
 
 RUN mkdir /deploy
-RUN git clone https://github.com/chrismattmann/imagecat.git
+RUN git clone -b docker-allow-override-of-list-file https://github.com/danlamanna/imagecat.git
 WORKDIR imagecat
 RUN mvn install
 RUN cp -R distribution/target/*.tar.gz /deploy
@@ -38,8 +38,8 @@ RUN mkdir -p /deploy/pge/extractors/filename
 COPY chunkfile_extractor.xml /deploy/pge/extractors/filename/chunkfile_extractor.xml
 COPY chunkfile_metout.xml /deploy/pge/extractors/metout/chunkfile_metout.xml
 
-RUN cp /deploy/filemgr/lib/cas-filemgr-*.jar /deploy/workflow/lib/ 
-RUN cp /deploy/filemgr/lib/cas-filemgr-*.jar /deploy/resmgr/lib/ 
+RUN cp /deploy/filemgr/lib/cas-filemgr-*.jar /deploy/workflow/lib/
+RUN cp /deploy/filemgr/lib/cas-filemgr-*.jar /deploy/resmgr/lib/
 RUN cp /deploy/filemgr/lib/cas-filemgr-*.jar /deploy/extensions/lib/
 
 COPY imagecatenv.sh /deploy/bin/imagecatenv.sh

--- a/DOCKER/Dockerfile
+++ b/DOCKER/Dockerfile
@@ -17,7 +17,7 @@ ENV JAVA_HOME=/usr/lib/jvm/java-7-openjdk-amd64
 ENV JRE_HOME=/usr/lib/jvm/java-7-openjdk-amd64
 
 RUN mkdir /deploy
-RUN git clone -b docker-allow-override-of-list-file https://github.com/danlamanna/imagecat.git
+RUN git clone https://github.com/chrismattmann/imagecat.git
 WORKDIR imagecat
 RUN mvn install
 RUN cp -R distribution/target/*.tar.gz /deploy
@@ -38,8 +38,8 @@ RUN mkdir -p /deploy/pge/extractors/filename
 COPY chunkfile_extractor.xml /deploy/pge/extractors/filename/chunkfile_extractor.xml
 COPY chunkfile_metout.xml /deploy/pge/extractors/metout/chunkfile_metout.xml
 
-RUN cp /deploy/filemgr/lib/cas-filemgr-*.jar /deploy/workflow/lib/
-RUN cp /deploy/filemgr/lib/cas-filemgr-*.jar /deploy/resmgr/lib/
+RUN cp /deploy/filemgr/lib/cas-filemgr-*.jar /deploy/workflow/lib/ 
+RUN cp /deploy/filemgr/lib/cas-filemgr-*.jar /deploy/resmgr/lib/ 
 RUN cp /deploy/filemgr/lib/cas-filemgr-*.jar /deploy/extensions/lib/
 
 COPY imagecatenv.sh /deploy/bin/imagecatenv.sh

--- a/DOCKER/README.md
+++ b/DOCKER/README.md
@@ -8,6 +8,11 @@ After building or pulling: `docker pull continuumio/imagecat`
 
 - `docker run -v /home/ubuntu/imagecat/DOCKER/images:/images -v /home/ubuntu/imagecat/DOCKER//staging:/deploy/data/staging/ -P -t -i continuumio/imagecat`
 
+Additionally you can specify a file other than ```staging/roxy-image-list-jpg-nonzero.txt``` by passing that filepath to the docker run statement:
+
+    docker run -v /home/ubuntu/imagecat/DOCKER/images:/images -v /home/ubuntu/imagecat/DOCKER//staging:/deploy/data/staging/ -P -t -i continuumio/imagecat my-image-list.txt
+
+
 A running container should result in starting all services: solr, tomcat, oodt, etc.  Last few lines of the running container will also expose 
 the hostname/container id
 

--- a/DOCKER/entrypoint_imagecatdev.sh
+++ b/DOCKER/entrypoint_imagecatdev.sh
@@ -8,5 +8,12 @@ cd $OODT_HOME/resmgr/bin/ && ./start-memex-stubs
 echo "Docker Container ID:" $HOSTNAME
 pushd $OODT_HOME/logs/
 python -m SimpleHTTPServer &
-echo "Watching /deploy/data/staging/roxy-image-list-jpg-nonzero.txt"
-while inotifywait -e close_write /deploy/data/staging/roxy-image-list-jpg-nonzero.txt; do $OODT_HOME/bin/chunker; done
+
+if [ -n "$1" ]; then
+    LIST_FILE=$1
+else
+    LIST_FILE=/deploy/data/staging/roxy-image-list-jpg-nonzero.txt
+fi
+
+echo "Watching $LIST_FILE"
+while inotifywait -e close_write $LIST_FILE; do $OODT_HOME/bin/chunker $LIST_FILE; done

--- a/distribution/src/main/resources/bin/chunker
+++ b/distribution/src/main/resources/bin/chunker
@@ -14,5 +14,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+if [ -n "$1" ]; then
+    LIST_FILE=$1
+else
+    LIST_FILE=$OODT_HOME/data/staging/roxy-image-list-jpg-nonzero.txt
+fi
+
 cd $OODT_HOME/workflow/bin
-./wmgr-client --url $WORKFLOW_URL --operation --dynWorkflow  --taskIds urn:memex:Chunker --metaData --key ImageListFile $OODT_HOME/data/staging/roxy-image-list-jpg-nonzero.txt
+./wmgr-client --url $WORKFLOW_URL --operation --dynWorkflow  --taskIds urn:memex:Chunker --metaData --key ImageListFile $LIST_FILE


### PR DESCRIPTION
This PR allows a user to pass their own list file to the imagecat entrypoint rather than requiring the file be named `roxy-image-list-jpg-nonzero.txt`.

This should maintain all backwards compatibility by defaulting to `roxy-image-list-jpg-nonzero.txt` if nothing is given.
