### PR TITLE
Add optional SimpleHTTPServer to docker run

### DIFF
--- a/DOCKER/Dockerfile
+++ b/DOCKER/Dockerfile
@@ -61,6 +61,7 @@ EXPOSE 8080
 EXPOSE 8081
 EXPOSE 8888
 EXPOSE 8000
+EXPOSE 9241
 
 COPY entrypoint_imagecatdev.sh /deploy/entrypoint_imagecatdev.sh
 

--- a/DOCKER/README.md
+++ b/DOCKER/README.md
@@ -1,14 +1,19 @@
 
 ## Building
-`docker build -t="continuumio/imagecat" .`
+
+    docker build -t="continuumio/imagecat" .
 
 ## Starting
 
 After building or pulling: `docker pull continuumio/imagecat`
 
-- `docker run -v /home/ubuntu/imagecat/DOCKER/images:/images -v /home/ubuntu/imagecat/DOCKER//staging:/deploy/data/staging/ -P -t -i continuumio/imagecat`
+    docker run -v /home/ubuntu/imagecat/DOCKER/images:/images -v /home/ubuntu/imagecat/DOCKER//staging:/deploy/data/staging/ -P -t -i continuumio/imagecat
 
-A running container should result in starting all services: solr, tomcat, oodt, etc.  Last few lines of the running container will also expose 
+If you're running ImageCat locally and need to host the images, you can set the environment variable ```IMAGECAT_IMAGE_PATH``` and the container will start a SimpleHTTPServer on port 9241, for example:
+
+    docker run -e IMAGECAT_IMAGE_PATH=/images ... continuumio/imagecat
+
+A running container should result in starting all services: solr, tomcat, oodt, etc.  Last few lines of the running container will also expose
 the hostname/container id
 
 ```
@@ -19,7 +24,7 @@ Setting up watches.
 Watches established.
 ```
 
-With a running docker containter you can now add images to the images dir: `imagecat/DOCKER/images` and update the list `staging/roxy-image-list-jpg-nonzero.txt`. 
+With a running docker container you can now add images to the images dir: `imagecat/DOCKER/images` and update the list `staging/roxy-image-list-jpg-nonzero.txt`.
 Updating the list will automatically result in the `chunker` script being executed
 
 ## Ports
@@ -32,5 +37,5 @@ docker port e622260b8701
 8000/tcp -> 0.0.0.0:49456
 ```
 
-8081 mapping is the solr instance where one can externally view/query.  Port 8000 has a simple webserver running in the logs directory for 
-help with debugging a running conatiner.  This should be switched out for logstash or docker's 1.6 logging facilities.
+8081 mapping is the solr instance where one can externally view/query.  Port 8000 has a simple webserver running in the logs directory for
+help with debugging a running container.  This should be switched out for logstash or docker's 1.6 logging facilities.

--- a/DOCKER/entrypoint_imagecatdev.sh
+++ b/DOCKER/entrypoint_imagecatdev.sh
@@ -8,5 +8,11 @@ cd $OODT_HOME/resmgr/bin/ && ./start-memex-stubs
 echo "Docker Container ID:" $HOSTNAME
 pushd $OODT_HOME/logs/
 python -m SimpleHTTPServer &
+
+if [ -n "$IMAGECAT_IMAGE_PATH" ] && [ -d "$IMAGECAT_IMAGE_PATH" ]; then
+    pushd $IMAGECAT_IMAGE_PATH
+    python -m SimpleHTTPServer 9241 &
+fi
+
 echo "Watching /deploy/data/staging/roxy-image-list-jpg-nonzero.txt"
 while inotifywait -e close_write /deploy/data/staging/roxy-image-list-jpg-nonzero.txt; do $OODT_HOME/bin/chunker; done


### PR DESCRIPTION
This PR allows the end user to add the following flag to their docker run command:

```
-e IMAGECAT_IMAGE_PATH=/images
```

where `/images` is the mounted volume for images on the container. This just runs a `SimpleHTTPServer` in that directory so ImageSpace can have the http url it requires to display images from ImageCat.
