### PR TITLE
Run OODT chunker on first run of docker container

### DIFF
--- a/DOCKER/entrypoint_imagecatdev.sh
+++ b/DOCKER/entrypoint_imagecatdev.sh
@@ -3,7 +3,7 @@ source $OODT_HOME/bin/imagecatenv.sh
 cd $OODT_HOME/bin && ./oodt start
 cd $OODT_HOME/tomcat7/bin && ./startup.sh
 cd $OODT_HOME/resmgr/bin/ && ./start-memex-stubs
-#$OODT_HOME/bin/chunker
+
 
 echo "Docker Container ID:" $HOSTNAME
 pushd $OODT_HOME/logs/
@@ -14,5 +14,13 @@ if [ -n "$IMAGECAT_IMAGE_PATH" ] && [ -d "$IMAGECAT_IMAGE_PATH" ]; then
     python -m SimpleHTTPServer 9241 &
 fi
 
-echo "Watching /deploy/data/staging/roxy-image-list-jpg-nonzero.txt"
-while inotifywait -e close_write /deploy/data/staging/roxy-image-list-jpg-nonzero.txt; do $OODT_HOME/bin/chunker; done
+$OODT_HOME/bin/chunker
+INITIAL_CHUNK=$?
+
+if [ $INITIAL_CHUNK -eq 0 ]; then
+    echo "Watching /deploy/data/staging/roxy-image-list-jpg-nonzero.txt"
+    while inotifywait -e close_write /deploy/data/staging/roxy-image-list-jpg-nonzero.txt; do $OODT_HOME/bin/chunker; done
+else
+    echo "Failed to run chunker"
+    exit 1
+fi


### PR DESCRIPTION
The docker container was only running the OODT chunker when the listing file changed, which was counter intuitive because starting the ImageCat container would show no images indexed until the listing file was modified.

This runs the OODT chunker on startup as well as when the listing file has changed.
