### PR TITLE
Pin transformers 4.x + sentencepiece so TrOCR actually loads

### DIFF
--- a/pge/src/main/resources/bin/imagecat-ocr/imagecat-ocr.py
+++ b/pge/src/main/resources/bin/imagecat-ocr/imagecat-ocr.py
@@ -58,7 +58,7 @@ def load_ocr(model_name: str):
     if name == "trocr":
         from transformers import TrOCRProcessor, VisionEncoderDecoderModel
 
-        processor = TrOCRProcessor.from_pretrained(TROCR_MODEL)
+        processor = TrOCRProcessor.from_pretrained(TROCR_MODEL, use_fast=False)
         model = VisionEncoderDecoderModel.from_pretrained(TROCR_MODEL)
 
         def ocr(path: str) -> str:

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,5 +4,7 @@
 
 pysolr>=3.9.0
 Pillow>=10.0.0
-transformers>=4.40.0
+# transformers 5.x broke TrOCRProcessor (tokenizer backend). Stay on 4.x.
+transformers>=4.40.0,<5
+sentencepiece>=0.2.0
 torch>=2.2.0


### PR DESCRIPTION
Found while OCR-ing five images from CHIPOTLE_BRICK `memex/raj_images`.

`pip install transformers>=4.40.0` currently resolves to 5.16.1, and that
line cannot construct `TrOCRProcessor` (\"Couldn't instantiate the backend
tokenizer\"). `sentencepiece` is also required for the printed TrOCR
checkpoint.

After this pin, the same five images indexed 5/5 into Solr 10
`http://localhost:8983/solr/imagecat`.