### PR TITLE
Use Lucene for the File Manager catalog (fixes OPSUI ChunkList -1)

### DIFF
--- a/filemgr/src/main/resources/etc/filemgr.properties
+++ b/filemgr/src/main/resources/etc/filemgr.properties
@@ -22,8 +22,11 @@ filemgr.client=org.apache.oodt.cas.filemgr.system.rpc.AvroFileManagerClientFacto
 # repository factory
 filemgr.repository.factory=org.apache.oodt.cas.filemgr.repository.XMLRepositoryManagerFactory
 
-# Lucene catalog factory
-filemgr.catalog.factory=org.apache.oodt.cas.filemgr.catalog.solr.SolrCatalogFactory
+# Lucene catalog factory. Solr 10 holds OCR documents (core imagecat). The
+# File Manager product catalog is Lucene, same as BigTranslate. SolrCatalog
+# still speaks Solr 4 XML; Solr 10 answers JSON unless wt=xml is set, and
+# getNumProducts then fails (OPSUI shows -1).
+filemgr.catalog.factory=org.apache.oodt.cas.filemgr.catalog.LuceneCatalogFactory
 
 # data transfer factory
 filemgr.datatransfer.factory=org.apache.oodt.cas.filemgr.datatransfer.LocalDataTransferFactory


### PR DESCRIPTION
OPSUI Catalog listed ChunkList with **numProducts -1**, and Recent products 500d, because ImageCat still used `SolrCatalogFactory` against Solr 10.

`DefaultProductSerializer` parses XML. Solr 4 defaulted to XML; Solr 10 defaults to JSON. `getNumProducts` then throws `Content is not allowed in prolog`, which FileManagerUtils turns into -1.

OCR stays in Solr core `imagecat`. File Manager products (ChunkList, etc.) go to Lucene, same as BigTranslate. The Solr catalog factory remains in `filemgr.fm-solr-catalog.properties` if someone wants it after Mnemosyne asks for `wt=xml`.

Verified live: after the switch and an empty Lucene index, `/pcs/services/catalog/types` returns ChunkList with `numProducts: 0`.