### PR TITLE
Put File Manager on the WM classpath so Chunker can run

### DIFF
--- a/distribution/src/main/resources/bin/imagecatenv.sh
+++ b/distribution/src/main/resources/bin/imagecatenv.sh
@@ -1,12 +1,20 @@
-export IMAGECAT_HOME=${IMAGECAT_HOME:-$(cd "$(dirname "$0")/.." && pwd)}
+# Convenience env for a shell. Prefer bin/setenv.sh (what bin/oodt
+# sources). Do not clobber URLs already set there — live ImageCat on a
+# box that also runs DRAT uses 9100/9101/9102, not 9000/9001/9002.
+HERE=$(cd "$(dirname "$0")/.." && pwd)
+if [ -r "$HERE/bin/setenv.sh" ]; then
+  # shellcheck disable=SC1091
+  . "$HERE/bin/setenv.sh"
+fi
+export IMAGECAT_HOME=${IMAGECAT_HOME:-$HERE}
 export OODT_HOME=${OODT_HOME:-$IMAGECAT_HOME}
-export FILEMGR_URL="http://localhost:9000"
-export WORKFLOW_URL="http://localhost:9001"
-export RESMGR_URL="http://localhost:9002"
-export FILEMGR_HOME=$OODT_HOME/filemgr
-export WORKFLOW_HOME=$OODT_HOME/workflow
-export PCS_HOME=$OODT_HOME/pcs
-export PGE_ROOT=$OODT_HOME/pge
+export FILEMGR_URL=${FILEMGR_URL:-http://localhost:${FILEMGR_PORT:-9000}}
+export WORKFLOW_URL=${WORKFLOW_URL:-http://localhost:${WORKFLOW_PORT:-9001}}
+export RESMGR_URL=${RESMGR_URL:-http://localhost:${RESMGR_PORT:-9002}}
+export FILEMGR_HOME=${FILEMGR_HOME:-$OODT_HOME/filemgr}
+export WORKFLOW_HOME=${WORKFLOW_HOME:-$OODT_HOME/workflow}
+export PCS_HOME=${PCS_HOME:-$OODT_HOME/pcs}
+export PGE_ROOT=${PGE_ROOT:-$OODT_HOME/pge}
 export PATH=${PCS_HOME}/bin:${PATH}
 if [ -d "$OODT_HOME/.venv/bin" ]; then
   export PATH=$OODT_HOME/.venv/bin:$PATH

--- a/distribution/src/main/resources/bin/ingest
+++ b/distribution/src/main/resources/bin/ingest
@@ -24,7 +24,7 @@ if [ "$#" -ne 1 ]; then
 else
 	export PRODUCT_PATH=$1
 	$DIR_PATH/../crawler/bin/crawler_launcher \
-	--filemgrUrl http://localhost:9000 \
+	--filemgrUrl ${FILEMGR_URL:-http://localhost:9000} \
 	--operation --launchMetCrawler \
 	--clientTransferer org.apache.oodt.cas.filemgr.datatransfer.InPlaceDataTransferFactory \
 	--productPath $1 \

--- a/distribution/src/main/resources/bin/setenv.sh
+++ b/distribution/src/main/resources/bin/setenv.sh
@@ -26,14 +26,21 @@
 ############################
 
 export IMAGECAT_HOME=${IMAGECAT_HOME:-/usr/local/imagecat}
+export OODT_HOME=${OODT_HOME:-$IMAGECAT_HOME}
 export FILEMGR_URL=http://localhost:9000
 export WORKFLOW_URL=http://localhost:9001
 export RESMGR_URL=http://localhost:9002
 export FILEMGR_HOME=$IMAGECAT_HOME/filemgr
+export WORKFLOW_HOME=$IMAGECAT_HOME/workflow
+export RESMGR_HOME=$IMAGECAT_HOME/resmgr
+export CRAWLER_HOME=$IMAGECAT_HOME/crawler
 export PGE_HOME=$IMAGECAT_HOME/pge
 export PGE_ROOT=$IMAGECAT_HOME/pge
 export PCS_HOME=$IMAGECAT_HOME/pcs
 export FMPROD_HOME=$IMAGECAT_HOME/tomcat/webapps/fmprod/WEB-INF/classes/
+if [ -d "$OODT_HOME/.venv/bin" ]; then
+  export PATH="$OODT_HOME/.venv/bin:$PATH"
+fi
 
 # Bound every Avro client call (Mnemosyne #197). Ten minutes is the code
 # default; 0 waits forever. JDK_JAVA_OPTIONS reaches File Manager, Workflow

--- a/distribution/src/main/resources/bin/setenv.sh
+++ b/distribution/src/main/resources/bin/setenv.sh
@@ -26,21 +26,14 @@
 ############################
 
 export IMAGECAT_HOME=${IMAGECAT_HOME:-/usr/local/imagecat}
-export OODT_HOME=${OODT_HOME:-$IMAGECAT_HOME}
 export FILEMGR_URL=http://localhost:9000
 export WORKFLOW_URL=http://localhost:9001
 export RESMGR_URL=http://localhost:9002
 export FILEMGR_HOME=$IMAGECAT_HOME/filemgr
-export WORKFLOW_HOME=$IMAGECAT_HOME/workflow
-export RESMGR_HOME=$IMAGECAT_HOME/resmgr
-export CRAWLER_HOME=$IMAGECAT_HOME/crawler
 export PGE_HOME=$IMAGECAT_HOME/pge
 export PGE_ROOT=$IMAGECAT_HOME/pge
 export PCS_HOME=$IMAGECAT_HOME/pcs
 export FMPROD_HOME=$IMAGECAT_HOME/tomcat/webapps/fmprod/WEB-INF/classes/
-if [ -d "$OODT_HOME/.venv/bin" ]; then
-  export PATH="$OODT_HOME/.venv/bin:$PATH"
-fi
 
 # Bound every Avro client call (Mnemosyne #197). Ten minutes is the code
 # default; 0 waits forever. JDK_JAVA_OPTIONS reaches File Manager, Workflow

--- a/workflow/pom.xml
+++ b/workflow/pom.xml
@@ -60,32 +60,24 @@
       <version>${project.parent.version}</version>
       <type>jar</type>
       <scope>runtime</scope>
-      <exclusions>
-        <exclusion>
-          <groupId>ai.mattmann.mnemosyne</groupId>
-          <artifactId>cas-filemgr</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <dependency>
       <groupId>ai.mattmann.mnemosyne</groupId>
       <artifactId>cas-workflow</artifactId>
       <version>${oodt.version}</version>
     </dependency>
+    <!-- Chunker / IngestInPlace are StdPGETaskInstance, run inside the
+         workflow manager process. PGE talks to File Manager and the
+         crawler; those jars have to be on workflow/lib. -->
+    <dependency>
+      <groupId>ai.mattmann.mnemosyne</groupId>
+      <artifactId>cas-filemgr</artifactId>
+      <version>${oodt.version}</version>
+    </dependency>
     <dependency>
       <groupId>ai.mattmann.mnemosyne</groupId>
       <artifactId>cas-pge</artifactId>
       <version>${oodt.version}</version>
-      <exclusions>
-        <exclusion>
-          <groupId>ai.mattmann.mnemosyne</groupId>
-          <artifactId>cas-filemgr</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>ai.mattmann.mnemosyne</groupId>
-          <artifactId>cas-crawler</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <dependency>
       <groupId>junit</groupId>


### PR DESCRIPTION
## Why

A dynWorkflow Chunker on the live overlay never left QUEUED. The WM thread died with:

`NoClassDefFoundError: org.apache.oodt.cas.filemgr.metadata.CoreMetKeys`

Chunker / IngestInPlace are `StdPGETaskInstance` and run **inside** the workflow manager. `workflow/pom.xml` excluded `cas-filemgr` from both `oodt-extensions` and `cas-pge`, so `workflow/lib` had PGE and crawler but not File Manager.

After copying `cas-filemgr-1.11.0.jar` into live `workflow/lib`:

- Chunker FINISHED
- IngestInPlace FINISHED
- ChunkList `numProducts: 1`
- Solr `imagecat` indexed 20/20 Raj stills

## Also

- `setenv.sh` exports `OODT_HOME` (PGE `[OODT_HOME]/data/jobs/...`)
- `imagecatenv.sh` sources `setenv.sh` and does not force 9000/9001 (DRAT lives there on the live box)
- `ingest` uses `$FILEMGR_URL`

Wiki updated separately.