### PR TITLE
Put Tika MIME/EXIF on the imagecat Solr core

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,8 +42,10 @@ OCR
 The IngestInPlace PGE calls `imagecat-ocr.py` over each chunk file.
 `--model trocr` (default) is printed/scene text;
 `--model donut` is document understanding and also fills `caption`.
-Tesseract and Solr Cell are gone. The old `solrcell_ingest` name remains as
-a shim onto the same script.
+Tika runs on each image in that same script (MIME, EXIF, IPTC) so the
+`imagecat` Solr core has the metadata Solr Cell used to attach. Tesseract
+and Solr Cell are gone. The old `solrcell_ingest` name remains as a shim
+onto the same script.
 
 ```bash
 python3 pge/bin/imagecat-ocr/imagecat-ocr.py \

--- a/docs/WHAT-IS-IN.md
+++ b/docs/WHAT-IS-IN.md
@@ -9,7 +9,7 @@ into Solr, File Manager catalogs the files. The stack under it is new.
 - RADiX layout (filemgr, workflow, resmgr, crawler, pge, pcs, distribution)
 - Chunker → Ingest-in-place → Solr
 - File Manager catalog (Solr core `oodt-fm`)
-- Tika MIME / EXIF on the File Manager ingest path (`ingestinplace`)
+- Tika MIME / EXIF on the Solr `imagecat` core (`imagecat-ocr.py`), the same place Solr Cell used to put it. File Manager catalogs ChunkList path files, not the images.
 - Vue OPSUI overlay of `ai.mattmann.mnemosyne:pcs-opsui`
 - image_space as the later search UI (lives in `nasa-jpl-memex/image_space`, not this repo)
 

--- a/pge/pom.xml
+++ b/pge/pom.xml
@@ -87,6 +87,19 @@
         </exclusion>
       </exclusions>
     </dependency>
+    <!-- Fat jar. imagecat-ocr.py shells out to tika-app -m for MIME/EXIF
+         the way Solr Cell used to. Exclude transitives; the jar is self-contained. -->
+    <dependency>
+      <groupId>org.apache.tika</groupId>
+      <artifactId>tika-app</artifactId>
+      <version>3.3.2</version>
+      <exclusions>
+        <exclusion>
+          <groupId>*</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>

--- a/pge/src/main/resources/bin/imagecat-ocr/imagecat-ocr.py
+++ b/pge/src/main/resources/bin/imagecat-ocr/imagecat-ocr.py
@@ -4,7 +4,7 @@
 # this work for additional information regarding copyright ownership.
 # The ASF licenses this file to You under the Apache License, Version 2.0
 # (the "License"); you may not use this file except in compliance with
-# the License.  You may obtain a copy of the License at
+# the License. You may obtain a copy of the License at
 #
 #     http://www.apache.org/licenses/LICENSE-2.0
 #
@@ -15,21 +15,40 @@
 # limitations under the License.
 #
 # OCR a chunk file of image paths with HuggingFace TrOCR (printed/scene
-# text) or Donut (documents), then POST the text to Solr. Replaces Solr
-# Cell + Tesseract. Tika MIME/EXIF stays on the File Manager ingest path.
+# text) or Donut (documents), then POST the text plus Tika MIME/EXIF to
+# Solr. Replaces Solr Cell + Tesseract. Solr Cell used to run Tika on
+# each image as it indexed; File Manager only catalogs the ChunkList
+# path files, so Tika has to happen here.
 
-"""OCR images listed in a chunk file and index the text in Solr."""
+"""OCR images listed in a chunk file and index the text plus Tika metadata in Solr."""
 
 from __future__ import annotations
 
 import argparse
 import hashlib
+import os
+import re
+import subprocess
 import sys
 from pathlib import Path
 
 
 TROCR_MODEL = "microsoft/trocr-base-printed"
 DONUT_MODEL = "naver-clova-ix/donut-base"
+MAX_TIKA_VALUE = 1024
+# ICC curves, padding, and per-component JPEG tables are not what SolrCell
+# users looked at, and they blow up a string field.
+SKIP_TIKA_PREFIXES = (
+    "ICC:",
+    "ICC ",
+    "Color Halftoning",
+    "Color Transfer",
+    "Component 1",
+    "Component 2",
+    "Component 3",
+)
+SKIP_TIKA_KEYS = {"Padding", "X-TIKA:content", "X-TIKA:Parsed-By", "X-TIKA:Parsed-By-Full-Set"}
+_FIELD_OK = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
 
 
 def sha1_of(path: str) -> str:
@@ -48,6 +67,111 @@ def read_chunk(chunk_file: str) -> list[str]:
             if path:
                 paths.append(path)
     return paths
+
+
+def solr_field_name(key: str) -> str:
+    """Solr 10 field names are [A-Za-z_][A-Za-z0-9_]*. SolrCell's Content-Type
+    lands on the explicit content_type field; everything else is sanitized
+    onto the catch-all dynamicField."""
+    if key in ("Content-Type", "ContentType", "content_type"):
+        return "content_type"
+    chars = []
+    for ch in key:
+        if ch.isalnum() or ch == "_":
+            chars.append(ch)
+        else:
+            chars.append("_")
+    name = "".join(chars)
+    name = re.sub(r"_+", "_", name).strip("_")
+    if not name:
+        return "tika_field"
+    if name[0].isdigit():
+        name = "t_" + name
+    if not _FIELD_OK.match(name):
+        return "tika_field"
+    return name
+
+
+def skip_tika_key(key: str) -> bool:
+    if key in SKIP_TIKA_KEYS:
+        return True
+    for prefix in SKIP_TIKA_PREFIXES:
+        if key.startswith(prefix):
+            return True
+    return False
+
+
+def parse_tika_metadata_text(text: str) -> dict[str, str]:
+    """Parse `tika-app -m` output: one 'Key: value' line per field."""
+    out = {}
+    for line in text.splitlines():
+        if ": " not in line:
+            continue
+        key, value = line.split(": ", 1)
+        key = key.strip()
+        value = value.strip()
+        if not key or skip_tika_key(key):
+            continue
+        if len(value) > MAX_TIKA_VALUE:
+            continue
+        if value.startswith("[") and value.endswith("values]"):
+            continue
+        field = solr_field_name(key)
+        if field in ("id", "ocr_text", "ocr_model_s", "sha1sum_s_md", "_version_"):
+            continue
+        out[field] = value
+    return out
+
+
+def find_tika_app() -> Path | None:
+    env = os.environ.get("TIKA_APP")
+    if env:
+        path = Path(env)
+        if path.is_file():
+            return path
+    roots = []
+    for key in ("PGE_ROOT", "PGE_HOME", "FILEMGR_HOME", "OODT_HOME", "IMAGECAT_HOME"):
+        val = os.environ.get(key)
+        if val:
+            roots.append(Path(val))
+    here = Path(__file__).resolve()
+    roots.append(here.parents[2])  # pge/
+    roots.append(here.parents[3] if len(here.parents) > 3 else here.parents[2])
+    for root in roots:
+        for lib in (root / "lib", root / "pge" / "lib"):
+            if not lib.is_dir():
+                continue
+            matches = sorted(lib.glob("tika-app-*.jar"))
+            if matches:
+                return matches[-1]
+    m2 = Path.home() / ".m2" / "repository" / "org" / "apache" / "tika" / "tika-app"
+    if m2.is_dir():
+        jars = sorted(m2.glob("*/tika-app-*.jar"))
+        if jars:
+            return jars[-1]
+    return None
+
+
+def tika_metadata(path: str, tika_app: Path | None) -> dict[str, str]:
+    if tika_app is None:
+        return {}
+    java = os.environ.get("JAVA_HOME", "")
+    java_bin = str(Path(java) / "bin" / "java") if java else "java"
+    try:
+        proc = subprocess.run(
+            [java_bin, "-jar", str(tika_app), "-m", path],
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=60,
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        print("Tika failed %s: %s" % (path, exc), file=sys.stderr)
+        return {}
+    if proc.returncode != 0:
+        print("Tika exit %s on %s: %s" % (proc.returncode, path, proc.stderr.strip()[:200]), file=sys.stderr)
+        return {}
+    return parse_tika_metadata_text(proc.stdout)
 
 
 def load_ocr(model_name: str):
@@ -114,6 +238,11 @@ def main(argv=None) -> int:
         help="trocr = printed/scene text (default); donut = document understanding",
     )
     parser.add_argument("--commit-every", type=int, default=32, help="Solr batch size")
+    parser.add_argument(
+        "--no-tika",
+        action="store_true",
+        help="Skip Tika MIME/EXIF (OCR text only). Default is to run Tika.",
+    )
     args = parser.parse_args(argv)
 
     chunk = Path(args.chunk_file)
@@ -126,6 +255,14 @@ def main(argv=None) -> int:
     print("Solr URL   : [%s]" % args.solr_url)
     print("OCR model  : [%s]" % args.model)
     print("Images     : [%d]" % len(paths))
+
+    tika_app = None if args.no_tika else find_tika_app()
+    if args.no_tika:
+        print("Tika       : skipped")
+    elif tika_app is None:
+        print("Tika       : tika-app.jar not found; MIME/EXIF will be missing", file=sys.stderr)
+    else:
+        print("Tika       : [%s]" % tika_app)
 
     ocr, hf_id = load_ocr(args.model)
     batch = []
@@ -150,6 +287,8 @@ def main(argv=None) -> int:
         }
         if args.model == "donut":
             doc["caption"] = text
+        if tika_app is not None:
+            doc.update(tika_metadata(path, tika_app))
         batch.append(doc)
         if len(batch) >= args.commit_every:
             index_docs(args.solr_url, batch)

--- a/solr/src/main/resources/imagecat/conf/schema.xml
+++ b/solr/src/main/resources/imagecat/conf/schema.xml
@@ -17,8 +17,9 @@
 -->
 <!--
   OCR / image-content core. id is the original file path. ocr_text is what
-  TrOCR or Donut produced. sha1sum_s_md is filled by the OCR PGE and by
-  sha1sum.py for documents that arrived without one.
+  TrOCR or Donut produced. Tika MIME/EXIF from imagecat-ocr.py lands on
+  content_type and the catch-all dynamicField (tiff_Make, Exif_IFD0_*, …).
+  sha1sum_s_md is filled by the OCR PGE and by sha1sum.py.
 -->
 <schema name="imagecat" version="1.6">
 

--- a/tests/test_pge_python.py
+++ b/tests/test_pge_python.py
@@ -1,6 +1,7 @@
 """Python 3 sanity checks for ImageCat PGE scripts. No HuggingFace, no Solr."""
 
 import ast
+import importlib.util
 import os
 import sys
 import tempfile
@@ -11,6 +12,11 @@ PGE_BIN = os.path.join(ROOT, "pge", "src", "main", "resources", "bin")
 sys.path.insert(0, os.path.join(PGE_BIN, "chunk_file"))
 
 import chunk_file  # noqa: E402
+
+_OCR_PATH = os.path.join(PGE_BIN, "imagecat-ocr", "imagecat-ocr.py")
+_SPEC = importlib.util.spec_from_file_location("imagecat_ocr", _OCR_PATH)
+ocr = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(ocr)
 
 
 class ChunkFileTests(unittest.TestCase):
@@ -42,6 +48,35 @@ class ChunkFileTests(unittest.TestCase):
         for path in scripts:
             with open(path, encoding="utf-8") as handle:
                 ast.parse(handle.read(), filename=path)
+
+
+class TikaSolrMappingTests(unittest.TestCase):
+    def test_content_type_field(self):
+        self.assertEqual(ocr.solr_field_name("Content-Type"), "content_type")
+
+    def test_exif_keys_become_solr_names(self):
+        self.assertEqual(ocr.solr_field_name("tiff:Make"), "tiff_Make")
+        self.assertEqual(ocr.solr_field_name("Exif IFD0:Date/Time"), "Exif_IFD0_Date_Time")
+
+    def test_parse_skips_icc_and_keeps_camera(self):
+        text = "\n".join([
+            "Content-Type: image/jpeg",
+            "tiff:Make: Canon",
+            "Exif IFD0:Model: Canon EOS-1D X",
+            "ICC:Green TRC: 0.0, 0.0000763, 0.0001526",
+            "Padding: [2060 values]",
+            "Color Halftoning Information: [72 values]",
+            "By-line: Matteo Chinellato",
+        ])
+        parsed = ocr.parse_tika_metadata_text(text)
+        self.assertEqual(parsed["content_type"], "image/jpeg")
+        self.assertEqual(parsed["tiff_Make"], "Canon")
+        self.assertEqual(parsed["Exif_IFD0_Model"], "Canon EOS-1D X")
+        self.assertEqual(parsed["By_line"], "Matteo Chinellato")
+        self.assertNotIn("ICC_Green_TRC", parsed)
+        self.assertNotIn("Padding", parsed)
+        self.assertFalse(any(k.startswith("ICC") for k in parsed))
+        self.assertFalse(any("Halftoning" in k for k in parsed))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Why

Solr Cell used to extract Tika metadata (Content-Type, EXIF Make/Model/DateTime, IPTC caption) onto each image document in `imagecatdev`. The overlay dropped Solr Cell, and `imagecat-ocr.py` only posted `id`, `ocr_text`, `ocr_model_s`, and `sha1sum_s_md`.

File Manager is not the right place for that metadata: it catalogs **ChunkList** path files, not the images. Tika has to run on the Solr image index path, same as Solr Cell.

## What

- `imagecat-ocr.py` shells out to `tika-app -m` (Tika 3.3.2, same as Mnemosyne)
- `Content-Type` → `content_type`
- `tiff:Make`, `Exif IFD0:Date/Time`, IPTC `Caption/Abstract`, width/height, … sanitized onto the catch-all dynamicField
- ICC curves / padding / JPEG component tables skipped (they are huge and not what anyone queried)
- `tika-app` is a pge dependency so it lands in `pge/lib`

## Live check

Re-indexed the 20 local Raj stills. `CHIN0010.jpg` now has `content_type=image/jpeg`, `tiff_Make=Canon`, `tiff_Model=Canon EOS-1D X`, `Exif_IFD0_Date_Time=2015:09:22 23:15:00`, `Caption_Abstract=Elisa Sednaoui - 72th Venice Film Festival`.

`--no-tika` keeps the OCR-only path. Tests cover the field mapping without HuggingFace or Solr.