### PR TITLE
CLIP/FAISS rebuild after IngestInPlace

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,10 @@ Tika runs on each image in that same script (MIME, EXIF, IPTC) so the
 and Solr Cell are gone. The old `solrcell_ingest` name remains as a shim
 onto the same script.
 
+FLAG: after ingest, ImageSpace CLIP/FAISS is stale until
+`urn:memex:IndexImageSpace` runs (`IMAGE_SPACE_HOME`, `--incremental`).
+The task is defined but commented on `IngestInPlace.workflow.xml`.
+
 ```bash
 python3 pge/bin/imagecat-ocr/imagecat-ocr.py \
   -f data/archive/chunks/0/filelist_chunk_0.txt \

--- a/docs/WHAT-IS-IN.md
+++ b/docs/WHAT-IS-IN.md
@@ -10,6 +10,7 @@ into Solr, File Manager catalogs the files. The stack under it is new.
 - Chunker → Ingest-in-place → Solr
 - File Manager catalog (Solr core `oodt-fm`)
 - Tika MIME / EXIF on the Solr `imagecat` core (`imagecat-ocr.py`), the same place Solr Cell used to put it. File Manager catalogs ChunkList path files, not the images.
+- FLAG: after IngestInPlace, ImageSpace CLIP/FAISS must be incremented (`urn:memex:IndexImageSpace`, commented on the IngestInPlace workflow until `IMAGE_SPACE_HOME` is set).
 - Vue OPSUI overlay of `ai.mattmann.mnemosyne:pcs-opsui`
 - image_space as the later search UI (lives in `nasa-jpl-memex/image_space`, not this repo)
 

--- a/pge/src/main/resources/bin/index-imagespace/index-imagespace.sh
+++ b/pge/src/main/resources/bin/index-imagespace/index-imagespace.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# FLAG: ImageSpace CLIP rebuild after ImageCat ingest.
+# No-op unless IMAGE_SPACE_HOME is set to the chrismattmann/image_space checkout.
+# Incremental encode of new Solr ids, then POST /api/clip/reload.
+set -euo pipefail
+
+if [ -z "${IMAGE_SPACE_HOME:-}" ]; then
+  echo "FLAG urn:memex:IndexImageSpace: IMAGE_SPACE_HOME is unset; skip CLIP rebuild"
+  exit 0
+fi
+
+SOLR_URL=${SolrUrl:-${IMAGE_SPACE_SOLR:-http://localhost:8983/solr/imagecat}}
+RELOAD=${IMAGE_SPACE_RELOAD_URL:-http://127.0.0.1:8090/api/clip/reload}
+PY=${IMAGE_SPACE_PYTHON:-python3}
+
+export IMAGE_SPACE_SOLR="$SOLR_URL"
+export PYTHONPATH="$IMAGE_SPACE_HOME"
+cd "$IMAGE_SPACE_HOME"
+echo "IndexImageSpace: incremental CLIP from $SOLR_URL"
+"$PY" -m server.embed --incremental --reload-url "$RELOAD"

--- a/pge/src/main/resources/policy/PgeConfig_IndexImageSpace.xml
+++ b/pge/src/main/resources/policy/PgeConfig_IndexImageSpace.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  FLAG: run after IngestInPlace so ImageSpace CLIP/FAISS sees new Solr docs.
+  The script no-ops unless IMAGE_SPACE_HOME is set. Do not full-rebuild the
+  catalog on every chunk — the indexer is --incremental.
+-->
+<pgeConfig>
+  <exe dir="[JobDir]" shell="/bin/bash">
+     <cmd>export PATH=[OODT_HOME]/bin/:[PGE_ROOT]/bin/index-imagespace:${PATH}</cmd>
+     <cmd>shopt -s expand_aliases</cmd>
+     <cmd>mkdir -p [JobOutputDir] [JobLogDir]</cmd>
+     <cmd>index-imagespace.sh</cmd>
+  </exe>
+  <output>
+    <dir path="[JobOutputDir]" createBeforeExe="false">
+    </dir>
+  </output>
+  <customMetadata>
+    <metadata key="ProductionDateTime" val="[DATE.UTC]"/>
+    <metadata key="DateMilis" val="[DATE_TO_MILLIS([ProductionDateTime],UTC_FORMAT,1970-01-01)]"/>
+    <metadata key="JobDir" val="[OODT_HOME]/data/jobs/imagespace/[DateMilis]"/>
+    <metadata key="JobOutputDir" val="[JobDir]/output"/>
+    <metadata key="JobLogDir" val="[JobDir]/logs"/>
+  </customMetadata>
+</pgeConfig>

--- a/workflow/src/main/resources/policy/IngestInPlace.workflow.xml
+++ b/workflow/src/main/resources/policy/IngestInPlace.workflow.xml
@@ -1,5 +1,9 @@
 <cas:workflow xmlns:cas="http://oodt.jpl.nasa.gov/1.0/cas" name="IngestInPlace" id="urn:memex:IngestInPlaceWorkflow">
  <tasks>
    <task id="urn:memex:IngestInPlaceTask"/>
+   <!-- FLAG: after OCR/Tika land in Solr, increment ImageSpace CLIP/FAISS.
+        Uncomment when IMAGE_SPACE_HOME is set on the workflow manager.
+        The task is defined in tasks.xml (urn:memex:IndexImageSpace). -->
+   <!-- <task id="urn:memex:IndexImageSpace"/> -->
  </tasks>
 </cas:workflow>

--- a/workflow/src/main/resources/policy/tasks.xml
+++ b/workflow/src/main/resources/policy/tasks.xml
@@ -83,4 +83,24 @@
     <requiredMetFields/>
   </task>
 
+  <!-- FLAG: after IngestInPlace OCR, increment CLIP/FAISS for ImageSpace.
+       Script no-ops unless IMAGE_SPACE_HOME is set. Not on the default
+       IngestInPlace workflow yet — see the commented task in
+       IngestInPlace.workflow.xml. -->
+  <task id="urn:memex:IndexImageSpace" name="IndexImageSpace" class="org.apache.oodt.cas.pge.StdPGETaskInstance">
+    <conditions/>
+    <configuration>
+      <property name="PGETask_Name" value="IndexImageSpace"/>
+      <property name="PGETask_ConfigFilePath" value="[PGE_ROOT]/policy/PgeConfig_IndexImageSpace.xml" envReplace="true"/>
+      <property name="PGETask_DumpMetadata" value="true"/>
+      <property name="PCS_WorkflowManagerUrl" value="[WORKFLOW_URL]" envReplace="true"/>
+      <property name="PCS_FileManagerUrl" value="[FILEMGR_URL]" envReplace="true"/>
+      <property name="PCS_MetFileExtension" value="met"/>
+      <property name="PCS_ClientTransferServiceFactory" value="org.apache.oodt.cas.filemgr.datatransfer.InPlaceDataTransferFactory"/>
+      <property name="PCS_ActionRepoFile" value="file:[CRAWLER_HOME]/policy/crawler-config.xml" envReplace="true"/>
+      <property name="SolrUrl" value="http://localhost:8983/solr/imagecat"/>
+    </configuration>
+    <requiredMetFields/>
+  </task>
+
 </cas:tasks>


### PR DESCRIPTION
After IngestInPlace writes OCR/Tika into Solr `imagecat`, run `urn:memex:IndexImageSpace`.

The script (`pge/bin/index-imagespace/index-imagespace.sh`) calls
`python -m server.embed --incremental` then `POST /api/clip/reload`.
That only encodes new Solr ids, concatenates CLIP vectors, and **rewrites**
FAISS (FlatIP until 10k, then HNSW).

It **no-ops** unless `IMAGE_SPACE_HOME` is set on the workflow manager
(optional `IMAGE_SPACE_PYTHON` for the Torch embed venv). Git `setenv.sh`
documents those as comments and stays on 9000/9001/9002.

The task is now on `IngestInPlace.workflow.xml` (was commented FLAG).