### PR TITLE
Label ChunkList copymet as ImageCat, not OODT

### DIFF
--- a/pge/src/main/resources/extractors/filename/chunkfile_extractor.xml
+++ b/pge/src/main/resources/extractors/filename/chunkfile_extractor.xml
@@ -43,7 +43,7 @@ the License.
              Also can use vector to indicate multiple values for a particular met field.
         -->
         <scalar name="DataVersion">1.0</scalar>
-        <scalar name="CollectionName">Products extracted by the OODT Filename Met Extractor</scalar>
-        <scalar name="DataProvider">OODT</scalar>
+        <scalar name="CollectionName">Products extracted by the ImageCat Filename Met Extractor</scalar>
+        <scalar name="DataProvider">ImageCat</scalar>
     </group>
 </input>

--- a/tests/test_pge_python.py
+++ b/tests/test_pge_python.py
@@ -49,6 +49,18 @@ class ChunkFileTests(unittest.TestCase):
             with open(path, encoding="utf-8") as handle:
                 ast.parse(handle.read(), filename=path)
 
+    def test_chunkfile_extractor_labels_are_imagecat(self):
+        path = os.path.join(
+            ROOT, "pge", "src", "main", "resources",
+            "extractors", "filename", "chunkfile_extractor.xml",
+        )
+        with open(path, encoding="utf-8") as handle:
+            text = handle.read()
+        self.assertIn("ImageCat Filename Met Extractor", text)
+        self.assertIn("<scalar name=\"DataProvider\">ImageCat</scalar>", text)
+        self.assertNotIn("OODT Filename Met Extractor", text)
+        self.assertNotIn("<scalar name=\"DataProvider\">OODT</scalar>", text)
+
 
 class TikaSolrMappingTests(unittest.TestCase):
     def test_content_type_field(self):


### PR DESCRIPTION
The Filename Met Extractor that copymet uses on Chunker / IngestInPlace
was still stamping:

- CollectionName: Products extracted by the OODT Filename Met Extractor
- DataProvider: OODT

Those show up on the ChunkList product in OPSUI. This sets both to ImageCat.

Does not change \`OODT_HOME\` env keys or Java class names.