### PR TITLE
Fix IndexImageSpace PGE XML comment (CLIP never rebuilt)

### DIFF
--- a/pge/src/main/resources/policy/PgeConfig_IndexImageSpace.xml
+++ b/pge/src/main/resources/policy/PgeConfig_IndexImageSpace.xml
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
-  FLAG: run after IngestInPlace so ImageSpace CLIP/FAISS sees new Solr docs.
-  The script no-ops unless IMAGE_SPACE_HOME is set. Do not full-rebuild the
-  catalog on every chunk — the indexer is --incremental.
+  After IngestInPlace, increment ImageSpace CLIP/FAISS.
+  The script no-ops unless IMAGE_SPACE_HOME is set.
+  Incremental encode of new Solr ids, then rewrite FAISS.
+  XML comments must not contain double-hyphen.
 -->
 <pgeConfig>
   <exe dir="[JobDir]" shell="/bin/bash">


### PR DESCRIPTION
PR #50 added \`PgeConfig_IndexImageSpace.xml\` with \`--incremental\` inside an XML comment. Double-hyphen is illegal in comments, so \`XmlFilePgeConfigBuilder\` got a null document and IndexImageSpace failed immediately after IngestInPlace.

CLIP stayed at 25 vectors while Solr grew to 691, which is why Similar said \"That image is not in the CLIP index\" for the new Raj pictures (including Johnny Depp).

Live copy of the policy file is already corrected.