### PR TITLE
IngestInPlace also rebuilds ImageSpace fg/bg CLIP

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,9 +47,9 @@ Tika runs on each image in that same script (MIME, EXIF, IPTC) so the
 and Solr Cell are gone. The old `solrcell_ingest` name remains as a shim
 onto the same script.
 
-FLAG: after ingest, ImageSpace CLIP/FAISS is stale until
-`urn:memex:IndexImageSpace` runs (`IMAGE_SPACE_HOME`, `--incremental`).
-The task is defined but commented on `IngestInPlace.workflow.xml`.
+After ingest, `urn:memex:IndexImageSpace` increments CLIP/FAISS and
+`urn:memex:IndexImageSpaceFgBg` increments foreground/background CLIP
+(U2-Net / rembg). Both no-op unless `IMAGE_SPACE_HOME` is set on the WM.
 
 ```bash
 python3 pge/bin/imagecat-ocr/imagecat-ocr.py \

--- a/pge/src/main/resources/bin/index-imagespace-fgbg/index-imagespace-fgbg.sh
+++ b/pge/src/main/resources/bin/index-imagespace-fgbg/index-imagespace-fgbg.sh
@@ -1,15 +1,15 @@
 #!/usr/bin/env bash
-# Incremental CLIP/FAISS after ImageCat ingest.
-# No-op unless IMAGE_SPACE_HOME is set.
+# Incremental CLIP foreground/background indexes after ImageCat ingest.
+# No-op unless IMAGE_SPACE_HOME is set. Needs rembg in the embed venv.
 set -euo pipefail
 
 if [ -z "${IMAGE_SPACE_HOME:-}" ]; then
-  echo "urn:memex:IndexImageSpace: IMAGE_SPACE_HOME is unset; skip CLIP rebuild"
+  echo "urn:memex:IndexImageSpaceFgBg: IMAGE_SPACE_HOME is unset; skip fg/bg CLIP"
   exit 0
 fi
 
 if [ ! -d "$IMAGE_SPACE_HOME" ]; then
-  echo "urn:memex:IndexImageSpace: IMAGE_SPACE_HOME=$IMAGE_SPACE_HOME is not a directory" >&2
+  echo "urn:memex:IndexImageSpaceFgBg: IMAGE_SPACE_HOME=$IMAGE_SPACE_HOME is not a directory" >&2
   exit 1
 fi
 
@@ -32,5 +32,5 @@ PY=$(pick_python)
 export IMAGE_SPACE_SOLR="$SOLR_URL"
 export PYTHONPATH="$IMAGE_SPACE_HOME"
 cd "$IMAGE_SPACE_HOME"
-echo "IndexImageSpace: incremental CLIP+FAISS from $SOLR_URL using $PY"
-"$PY" -m server.embed --incremental --reload-url "$RELOAD"
+echo "IndexImageSpaceFgBg: incremental fg/bg CLIP from $SOLR_URL using $PY"
+"$PY" -m server.embed_fgbg --incremental --reload-url "$RELOAD"

--- a/pge/src/main/resources/policy/PgeConfig_IndexImageSpaceFgBg.xml
+++ b/pge/src/main/resources/policy/PgeConfig_IndexImageSpaceFgBg.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  After IndexImageSpace, increment ImageSpace foreground/background CLIP.
+  The script no-ops unless IMAGE_SPACE_HOME is set.
+  Incremental encode of new Solr ids. XML comments must not contain
+  double-hyphen.
+-->
+<pgeConfig>
+  <exe dir="[JobDir]" shell="/bin/bash">
+     <cmd>export PATH=[OODT_HOME]/bin/:[PGE_ROOT]/bin/index-imagespace-fgbg:${PATH}</cmd>
+     <cmd>shopt -s expand_aliases</cmd>
+     <cmd>mkdir -p [JobOutputDir] [JobLogDir]</cmd>
+     <cmd>index-imagespace-fgbg.sh</cmd>
+  </exe>
+  <output>
+    <dir path="[JobOutputDir]" createBeforeExe="false">
+    </dir>
+  </output>
+  <customMetadata>
+    <metadata key="ProductionDateTime" val="[DATE.UTC]"/>
+    <metadata key="DateMilis" val="[DATE_TO_MILLIS([ProductionDateTime],UTC_FORMAT,1970-01-01)]"/>
+    <metadata key="JobDir" val="[OODT_HOME]/data/jobs/imagespace-fgbg/[DateMilis]"/>
+    <metadata key="JobOutputDir" val="[JobDir]/output"/>
+    <metadata key="JobLogDir" val="[JobDir]/logs"/>
+  </customMetadata>
+</pgeConfig>

--- a/tests/test_pge_python.py
+++ b/tests/test_pge_python.py
@@ -49,6 +49,17 @@ class ChunkFileTests(unittest.TestCase):
             with open(path, encoding="utf-8") as handle:
                 ast.parse(handle.read(), filename=path)
 
+    def test_index_imagespace_skips_without_home(self):
+        import subprocess
+
+        env = os.environ.copy()
+        env.pop("IMAGE_SPACE_HOME", None)
+        env.pop("IMAGE_SPACE_PYTHON", None)
+        for name in ("index-imagespace", "index-imagespace-fgbg"):
+            script = os.path.join(PGE_BIN, name, name + ".sh")
+            out = subprocess.check_output(["bash", script], env=env, text=True)
+            self.assertIn("unset; skip", out)
+
     def test_chunkfile_extractor_labels_are_imagecat(self):
         path = os.path.join(
             ROOT, "pge", "src", "main", "resources",

--- a/workflow/src/main/resources/policy/IngestInPlace.workflow.xml
+++ b/workflow/src/main/resources/policy/IngestInPlace.workflow.xml
@@ -1,9 +1,9 @@
 <cas:workflow xmlns:cas="http://oodt.jpl.nasa.gov/1.0/cas" name="IngestInPlace" id="urn:memex:IngestInPlaceWorkflow">
  <tasks>
    <task id="urn:memex:IngestInPlaceTask"/>
-   <!-- FLAG: after OCR/Tika land in Solr, increment ImageSpace CLIP/FAISS.
-        Uncomment when IMAGE_SPACE_HOME is set on the workflow manager.
-        The task is defined in tasks.xml (urn:memex:IndexImageSpace). -->
-   <!-- <task id="urn:memex:IndexImageSpace"/> -->
+   <!-- After OCR/Tika land in Solr imagecat, increment ImageSpace CLIP/FAISS
+        then fg/bg CLIP. Scripts no-op unless IMAGE_SPACE_HOME is set on the WM. -->
+   <task id="urn:memex:IndexImageSpace"/>
+   <task id="urn:memex:IndexImageSpaceFgBg"/>
  </tasks>
 </cas:workflow>

--- a/workflow/src/main/resources/policy/tasks.xml
+++ b/workflow/src/main/resources/policy/tasks.xml
@@ -83,15 +83,31 @@
     <requiredMetFields/>
   </task>
 
-  <!-- FLAG: after IngestInPlace OCR, increment CLIP/FAISS for ImageSpace.
-       Script no-ops unless IMAGE_SPACE_HOME is set. Not on the default
-       IngestInPlace workflow yet — see the commented task in
-       IngestInPlace.workflow.xml. -->
+  <!-- After IngestInPlace OCR, increment CLIP/FAISS for ImageSpace.
+       Script no-ops unless IMAGE_SPACE_HOME is set on the workflow manager. -->
   <task id="urn:memex:IndexImageSpace" name="IndexImageSpace" class="org.apache.oodt.cas.pge.StdPGETaskInstance">
     <conditions/>
     <configuration>
       <property name="PGETask_Name" value="IndexImageSpace"/>
       <property name="PGETask_ConfigFilePath" value="[PGE_ROOT]/policy/PgeConfig_IndexImageSpace.xml" envReplace="true"/>
+      <property name="PGETask_DumpMetadata" value="true"/>
+      <property name="PCS_WorkflowManagerUrl" value="[WORKFLOW_URL]" envReplace="true"/>
+      <property name="PCS_FileManagerUrl" value="[FILEMGR_URL]" envReplace="true"/>
+      <property name="PCS_MetFileExtension" value="met"/>
+      <property name="PCS_ClientTransferServiceFactory" value="org.apache.oodt.cas.filemgr.datatransfer.InPlaceDataTransferFactory"/>
+      <property name="PCS_ActionRepoFile" value="file:[CRAWLER_HOME]/policy/crawler-config.xml" envReplace="true"/>
+      <property name="SolrUrl" value="http://localhost:8983/solr/imagecat"/>
+    </configuration>
+    <requiredMetFields/>
+  </task>
+
+  <!-- After CLIP, increment foreground/background CLIP. No-op unless
+       IMAGE_SPACE_HOME is set. Needs rembg in the ImageSpace embed venv. -->
+  <task id="urn:memex:IndexImageSpaceFgBg" name="IndexImageSpaceFgBg" class="org.apache.oodt.cas.pge.StdPGETaskInstance">
+    <conditions/>
+    <configuration>
+      <property name="PGETask_Name" value="IndexImageSpaceFgBg"/>
+      <property name="PGETask_ConfigFilePath" value="[PGE_ROOT]/policy/PgeConfig_IndexImageSpaceFgBg.xml" envReplace="true"/>
       <property name="PGETask_DumpMetadata" value="true"/>
       <property name="PCS_WorkflowManagerUrl" value="[WORKFLOW_URL]" envReplace="true"/>
       <property name="PCS_FileManagerUrl" value="[FILEMGR_URL]" envReplace="true"/>


### PR DESCRIPTION
After IngestInPlace OCR/Tika:

1. \`urn:memex:IndexImageSpace\` incremental CLIP/FAISS
2. \`urn:memex:IndexImageSpaceFgBg\` incremental rembg + CLIP on fg and bg stills

Both no-op unless \`IMAGE_SPACE_HOME\` is set. That is why FG/BG similar 404s on new ingest until this runs (or \`python -m server.embed_fgbg --incremental\`).

Copied onto live ImageCat; WM restarted so the new task is loaded.