### PR TITLE
Point ImageSpace CLIP jobs at the PGE job dir for .progress

### DIFF
--- a/pge/src/main/resources/bin/index-imagespace-fgbg/index-imagespace-fgbg.sh
+++ b/pge/src/main/resources/bin/index-imagespace-fgbg/index-imagespace-fgbg.sh
@@ -31,6 +31,8 @@ PY=$(pick_python)
 
 export IMAGE_SPACE_SOLR="$SOLR_URL"
 export PYTHONPATH="$IMAGE_SPACE_HOME"
+# JobDir is cwd when the PGE starts us; python cds to IMAGE_SPACE_HOME.
+export PGE_PROGRESS_DIR="${PGE_PROGRESS_DIR:-$PWD}"
 cd "$IMAGE_SPACE_HOME"
 echo "IndexImageSpaceFgBg: incremental fg/bg CLIP from $SOLR_URL using $PY"
 "$PY" -m server.embed_fgbg --incremental --reload-url "$RELOAD"

--- a/pge/src/main/resources/bin/index-imagespace/index-imagespace.sh
+++ b/pge/src/main/resources/bin/index-imagespace/index-imagespace.sh
@@ -31,6 +31,8 @@ PY=$(pick_python)
 
 export IMAGE_SPACE_SOLR="$SOLR_URL"
 export PYTHONPATH="$IMAGE_SPACE_HOME"
+# JobDir is cwd when the PGE starts us; python cds to IMAGE_SPACE_HOME.
+export PGE_PROGRESS_DIR="${PGE_PROGRESS_DIR:-$PWD}"
 cd "$IMAGE_SPACE_HOME"
 echo "IndexImageSpace: incremental CLIP+FAISS from $SOLR_URL using $PY"
 "$PY" -m server.embed --incremental --reload-url "$RELOAD"


### PR DESCRIPTION
The IndexImageSpace scripts cd into \`IMAGE_SPACE_HOME\` before python runs. Export \`PGE_PROGRESS_DIR=\$PWD\` first (the job working directory) so \`.progress\` lands where StdPGETaskInstance watches it.