### PR TITLE
Ship ImageSpace in the ImageCat tarball

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@ __pycache__/
 .idea/
 .DS_Store
 *.bak
+imagespace/web/node_modules/
+imagespace/web/dist/
+imagespace/data/

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ bin/oodt start              # File Manager, Workflow, Resource, Tomcat 9, Solr 1
 ```
 
 - OPSUI: `http://localhost:8080/opsui/`
+- ImageSpace: `http://127.0.0.1:8090/`
 - Solr OCR core: `http://localhost:8983/solr/imagecat`
 - Solr FM catalog: `http://localhost:8983/solr/oodt-fm`
 
@@ -47,9 +48,11 @@ Tika runs on each image in that same script (MIME, EXIF, IPTC) so the
 and Solr Cell are gone. The old `solrcell_ingest` name remains as a shim
 onto the same script.
 
-After ingest, `urn:memex:IndexImageSpace` increments CLIP/FAISS and
+ImageSpace (analyst UI, CLIP, fg/bg, IQR) ships in this tarball. `bin/oodt start`
+brings it up on `http://127.0.0.1:8090/` (FastAPI, like Solr). After ingest,
+`urn:memex:IndexImageSpace` increments CLIP/FAISS and
 `urn:memex:IndexImageSpaceFgBg` increments foreground/background CLIP
-(U2-Net / rembg). Both no-op unless `IMAGE_SPACE_HOME` is set on the WM.
+(U2-Net / rembg). Indexes live under `$IMAGECAT_HOME/data/imagespace/`.
 
 ```bash
 python3 pge/bin/imagecat-ocr/imagecat-ocr.py \

--- a/distribution/src/main/assembly/assembly.xml
+++ b/distribution/src/main/assembly/assembly.xml
@@ -108,6 +108,26 @@
       </includes>
     </fileSet>
     <fileSet>
+      <directory>${basedir}/../imagespace</directory>
+      <outputDirectory>imagespace</outputDirectory>
+      <excludes>
+        <exclude>web/node_modules/**</exclude>
+        <exclude>web/dist/**</exclude>
+        <exclude>data/**</exclude>
+        <exclude>**/__pycache__/**</exclude>
+        <exclude>**/*.pyc</exclude>
+        <exclude>.venv/**</exclude>
+        <exclude>.venv-embed/**</exclude>
+      </excludes>
+    </fileSet>
+    <fileSet>
+      <directory>target</directory>
+      <outputDirectory>data/imagespace</outputDirectory>
+      <excludes>
+        <exclude>**/*</exclude>
+      </excludes>
+    </fileSet>
+    <fileSet>
       <directory>${project.build.directory}/solr-${solr.version}</directory>
       <outputDirectory>solr-server</outputDirectory>
       <excludes><exclude>bin/**</exclude></excludes>

--- a/distribution/src/main/resources/bin/imagecat-setup
+++ b/distribution/src/main/resources/bin/imagecat-setup
@@ -33,5 +33,24 @@ fi
 "$PYTHON" -m venv "$VENV"
 "$VENV/bin/python" -m pip install --upgrade pip
 "$VENV/bin/python" -m pip install -r "$REQ"
+if [ -f "$IMAGECAT_HOME/imagespace/requirements-embed.txt" ]; then
+  (cd "$IMAGECAT_HOME/imagespace" && "$VENV/bin/python" -m pip install -r requirements-embed.txt) || \
+    echo "CLIP extra (torch) already covered by requirements.txt or failed; CLIP ingest needs it" >&2
+fi
+if [ -f "$IMAGECAT_HOME/imagespace/requirements-iqr.txt" ]; then
+  (cd "$IMAGECAT_HOME/imagespace" && "$VENV/bin/python" -m pip install -r requirements-iqr.txt) || \
+    echo "IQR extra (keras) skipped; similar still works without it" >&2
+fi
+# rembg is optional; fg/bg ingest no-ops usefully if missing.
+"$VENV/bin/python" -m pip install rembg onnxruntime >/dev/null 2>&1 || \
+  echo "rembg not installed; IndexImageSpaceFgBg will skip until pip install rembg onnxruntime" >&2
+
+if [ -f "$IMAGECAT_HOME/imagespace/web/package.json" ]; then
+  if command -v npm >/dev/null 2>&1; then
+    (cd "$IMAGECAT_HOME/imagespace/web" && npm ci && npm run build)
+  else
+    echo "npm not on PATH; ImageSpace UI will be API-only until: cd imagespace/web && npm ci && npm run build" >&2
+  fi
+fi
 echo "Installed into $VENV"
 echo "Restart ImageCat so PGEs pick up $VENV/bin: bin/oodt stop && bin/oodt start"

--- a/distribution/src/main/resources/bin/imagespace
+++ b/distribution/src/main/resources/bin/imagespace
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Start/stop the ImageSpace FastAPI process (analyst UI + /api).
+# Solr-shaped sidecar: own pid file, own port, started from bin/oodt.
+
+set -euo pipefail
+
+HERE=$(cd "$(dirname "$0")/.." && pwd)
+OODT_HOME=${OODT_HOME:-$HERE}
+IMAGE_SPACE_HOME=${IMAGE_SPACE_HOME:-$OODT_HOME/imagespace}
+PORT=${IMAGESPACE_PORT:-8090}
+PIDFILE=${IMAGESPACE_PID:-$OODT_HOME/run/imagespace.pid}
+LOG=${IMAGESPACE_LOG:-$OODT_HOME/logs/imagespace.out}
+PY=${IMAGE_SPACE_PYTHON:-$OODT_HOME/.venv/bin/python}
+
+pick_python() {
+  if [ -x "$PY" ]; then
+    echo "$PY"
+    return
+  fi
+  if [ -x "$OODT_HOME/.venv/bin/python" ]; then
+    echo "$OODT_HOME/.venv/bin/python"
+    return
+  fi
+  echo python3
+}
+
+is_running() {
+  if [ ! -f "$PIDFILE" ]; then
+    return 1
+  fi
+  pid=$(cat "$PIDFILE")
+  kill -0 "$pid" 2>/dev/null
+}
+
+start() {
+  if [ ! -d "$IMAGE_SPACE_HOME/server" ]; then
+    echo "ImageSpace is not installed at $IMAGE_SPACE_HOME" >&2
+    return 1
+  fi
+  if is_running; then
+    echo "ImageSpace already running (pid $(cat "$PIDFILE"))"
+    return 0
+  fi
+  mkdir -p "$OODT_HOME/run" "$OODT_HOME/logs" \
+    "$OODT_HOME/data/imagespace/clip" \
+    "$OODT_HOME/data/imagespace/fg" \
+    "$OODT_HOME/data/imagespace/bg" \
+    "$OODT_HOME/data/imagespace/thumbs"
+  PYTHON=$(pick_python)
+  export OODT_HOME IMAGECAT_HOME=${IMAGECAT_HOME:-$OODT_HOME}
+  export IMAGE_SPACE_HOME
+  export IMAGE_SPACE_DATA=${IMAGE_SPACE_DATA:-$OODT_HOME/data/imagespace}
+  export IMAGE_SPACE_SOLR=${IMAGE_SPACE_SOLR:-http://localhost:8983/solr/imagecat}
+  export PYTHONPATH="$IMAGE_SPACE_HOME${PYTHONPATH:+:$PYTHONPATH}"
+  cd "$IMAGE_SPACE_HOME"
+  nohup "$PYTHON" -m uvicorn server.main:app --host 127.0.0.1 --port "$PORT" \
+    >> "$LOG" 2>&1 &
+  echo $! > "$PIDFILE"
+  echo "Started ImageSpace pid $(cat "$PIDFILE") on http://127.0.0.1:$PORT/"
+}
+
+stop() {
+  if ! is_running; then
+    rm -f "$PIDFILE"
+    echo "ImageSpace is not running"
+    return 0
+  fi
+  pid=$(cat "$PIDFILE")
+  kill "$pid" 2>/dev/null || true
+  for _ in 1 2 3 4 5; do
+    kill -0 "$pid" 2>/dev/null || break
+    sleep 0.2
+  done
+  if kill -0 "$pid" 2>/dev/null; then
+    kill -9 "$pid" 2>/dev/null || true
+  fi
+  rm -f "$PIDFILE"
+  echo "Stopped ImageSpace"
+}
+
+case "${1:-}" in
+  start) start ;;
+  stop) stop ;;
+  *)
+    echo "Usage: imagespace start|stop" >&2
+    exit 1
+    ;;
+esac

--- a/distribution/src/main/resources/bin/oodt
+++ b/distribution/src/main/resources/bin/oodt
@@ -109,6 +109,11 @@ if [ "$1" = "start" ]; then
     nohup "$SOLR_SERVER_HOME"/bin/"$SOLR_EXEC" start -p "$SOLR_PORT" \
       --solr-home "$OODT_BASE"/solr --user-managed >> "$OODT_OUT" 2>&1 &
   fi
+  # ImageSpace is a Python sidecar (FastAPI), same idea as Solr: own
+  # process, own port. No-op if the module was not packed into this distro.
+  if [ -x "$OODT_BASE"/bin/imagespace ]; then
+    "$OODT_BASE"/bin/imagespace start >> "$OODT_OUT" 2>&1 || true
+  fi
   sleep 0.2s
 # Print confirmation messages to the end user
 # FileManager
@@ -162,6 +167,14 @@ if [ "$1" = "start" ]; then
         echo -e 'Starting OODT Workflow Manager [' $'\e[31m' 'Failed' $'\e[00m' ']'
     fi
   fi
+
+# ImageSpace
+  if [ -e "$OODT_BASE/run/imagespace.pid" ] && kill -0 "$(cat "$OODT_BASE/run/imagespace.pid")" > /dev/null 2>&1;
+  then
+      echo -e 'Starting ImageSpace [' $'\e[32m' 'Successful' $'\e[00m' ']'
+  else
+      echo -e 'Starting ImageSpace [' $'\e[31m' 'Failed' $'\e[00m' ']'
+  fi
 elif [ "$1" = "stop" ]; then
   exec "$FILEMGR_HOME"/bin/"$FILEMGR_EXEC" stop "$@" >> "$OODT_OUT" 2>&1  &
   exec "$WORKFLOW_HOME"/bin/"$WORKFLOW_EXEC" stop "$@" >> "$OODT_OUT" 2>&1 &
@@ -169,6 +182,9 @@ elif [ "$1" = "stop" ]; then
   exec "$OODT_BASE"/tomcat/bin/"$TOMCAT_EXEC" stop "$@" >> "$OODT_OUT" 2>&1 &
   if [ -x "$SOLR_SERVER_HOME"/bin/"$SOLR_EXEC" ]; then
     "$SOLR_SERVER_HOME"/bin/"$SOLR_EXEC" stop -p "$SOLR_PORT" >> "$OODT_OUT" 2>&1 &
+  fi
+  if [ -x "$OODT_BASE"/bin/imagespace ]; then
+    "$OODT_BASE"/bin/imagespace stop >> "$OODT_OUT" 2>&1 || true
   fi
 else
   echo "Usage: oodt.sh ( commands ... )"

--- a/distribution/src/main/resources/bin/setenv.sh
+++ b/distribution/src/main/resources/bin/setenv.sh
@@ -35,6 +35,15 @@ export PGE_ROOT=$IMAGECAT_HOME/pge
 export PCS_HOME=$IMAGECAT_HOME/pcs
 export FMPROD_HOME=$IMAGECAT_HOME/tomcat/webapps/fmprod/WEB-INF/classes/
 
+# ImageSpace lives in this tarball. CLIP/fg/bg ingest hooks use these.
+export IMAGE_SPACE_HOME=$IMAGECAT_HOME/imagespace
+export IMAGE_SPACE_DATA=$IMAGECAT_HOME/data/imagespace
+export IMAGE_SPACE_SOLR=http://localhost:8983/solr/imagecat
+export IMAGESPACE_PORT=8090
+if [ -x "$IMAGECAT_HOME/.venv/bin/python" ]; then
+  export IMAGE_SPACE_PYTHON=$IMAGECAT_HOME/.venv/bin/python
+fi
+
 # Bound every Avro client call (Mnemosyne #197). Ten minutes is the code
 # default; 0 waits forever. JDK_JAVA_OPTIONS reaches File Manager, Workflow
 # Manager, Resource Manager, and Tomcat.

--- a/docs/WHAT-IS-IN.md
+++ b/docs/WHAT-IS-IN.md
@@ -10,9 +10,9 @@ into Solr, File Manager catalogs the files. The stack under it is new.
 - Chunker → Ingest-in-place → Solr
 - File Manager catalog (Solr core `oodt-fm`)
 - Tika MIME / EXIF on the Solr `imagecat` core (`imagecat-ocr.py`), the same place Solr Cell used to put it. File Manager catalogs ChunkList path files, not the images.
-- FLAG: after IngestInPlace, ImageSpace CLIP/FAISS must be incremented (`urn:memex:IndexImageSpace`, commented on the IngestInPlace workflow until `IMAGE_SPACE_HOME` is set).
+- FLAG: after IngestInPlace, ImageSpace CLIP/FAISS and fg/bg are incremented (`urn:memex:IndexImageSpace`, `urn:memex:IndexImageSpaceFgBg`).
 - Vue OPSUI overlay of `ai.mattmann.mnemosyne:pcs-opsui`
-- image_space as the later search UI (lives in `nasa-jpl-memex/image_space`, not this repo)
+- ImageSpace analyst UI in this repo (`imagespace/`), started by `bin/oodt start` on port 8090. Indexes under `$OODT_HOME/data/imagespace/`. The NASA Girder/SMQTK ImageSpace stays at `nasa-jpl-memex/image_space`.
 
 ## Throw out
 
@@ -42,12 +42,10 @@ into Solr, File Manager catalogs the files. The stack under it is new.
 | `solrcell_ingest` curl loop | same name, now a shim onto `imagecat-ocr.py` |
 | `python2.7` shebangs and `print` / `long()` | Python 3 |
 
-## Replace later (image_space, not this repo)
+## Replace later
 
-- SMQTK
-- FLANN
-- CMU / Columbia / Georgetown extractors
-- Girder / Mongo
+- SMQTK / FLANN / Caffe (already replaced in-tree by CLIP + rembg + Keras)
+- Columbia / Georgetown / weapons / VideoSpace (not v1)
 
 SCE domain discovery stays public for Sparkler. Sparkler itself lives at
 [gitlab.com/sparkler-crawl-environment/sparkler](https://gitlab.com/sparkler-crawl-environment/sparkler).

--- a/imagespace/README.md
+++ b/imagespace/README.md
@@ -1,0 +1,17 @@
+# ImageSpace (inside ImageCat)
+
+Analyst desktop for this RADiX stack: Solr search, CLIP similar, fg/bg,
+IQR. Packed into the ImageCat tarball and started by `bin/oodt start`
+(FastAPI on port 8090, same idea as Solr).
+
+CLIP / fg / bg files live under `$OODT_HOME/data/imagespace/`, not in git.
+
+```bash
+bin/imagecat-setup    # .venv + Vue build
+bin/oodt start        # includes ImageSpace
+# UI: http://127.0.0.1:8090/
+```
+
+Vite on 5173 is optional for UI development (`cd imagespace/web && npm run dev`).
+The ingest PGEs (`urn:memex:IndexImageSpace`, `IndexImageSpaceFgBg`) use
+`IMAGE_SPACE_HOME=$OODT_HOME/imagespace` from `bin/setenv.sh`.

--- a/imagespace/bin/rebuild-clip
+++ b/imagespace/bin/rebuild-clip
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# Incremental CLIP index from ImageCat Solr, rewrite FAISS, reload the API.
+set -euo pipefail
+HERE=$(cd "$(dirname "$0")/.." && pwd)
+OODT_HOME=${OODT_HOME:-${IMAGECAT_HOME:-}}
+cd "$HERE"
+export PYTHONPATH="$HERE"
+export IMAGE_SPACE_SOLR=${IMAGE_SPACE_SOLR:-http://localhost:8983/solr/imagecat}
+if [ -n "$OODT_HOME" ]; then
+  export IMAGE_SPACE_DATA=${IMAGE_SPACE_DATA:-$OODT_HOME/data/imagespace}
+fi
+if [ -n "${IMAGE_SPACE_PYTHON:-}" ]; then
+  PY=$IMAGE_SPACE_PYTHON
+elif [ -n "$OODT_HOME" ] && [ -x "$OODT_HOME/.venv/bin/python" ]; then
+  PY=$OODT_HOME/.venv/bin/python
+elif [ -x "$HERE/.venv-embed/bin/python" ]; then
+  PY=$HERE/.venv-embed/bin/python
+else
+  PY=python3
+fi
+"$PY" -m server.embed --incremental "$@"

--- a/imagespace/docs/IMAGECAT-HOOK.md
+++ b/imagespace/docs/IMAGECAT-HOOK.md
@@ -1,0 +1,34 @@
+# ImageCat ingest rebuilds CLIP and fg/bg
+
+After IngestInPlace writes OCR/Tika into Solr `imagecat`, ImageCat runs:
+
+1. `urn:memex:IndexImageSpace` (`pge/bin/index-imagespace/index-imagespace.sh`)
+   — `python -m server.embed --incremental`
+2. `urn:memex:IndexImageSpaceFgBg` (`pge/bin/index-imagespace-fgbg/index-imagespace-fgbg.sh`)
+   — `python -m server.embed_fgbg --incremental`
+
+`bin/setenv.sh` sets `IMAGE_SPACE_HOME=$OODT_HOME/imagespace`. Optional
+`IMAGE_SPACE_PYTHON` points at `$OODT_HOME/.venv/bin/python`. Then they
+POST `/api/clip/reload`.
+
+`--incremental` only encodes Solr ids not already in the index (`data/clip/ids.json`,
+or `data/fg` / `data/bg` for the split). It concatenates the new CLIP rows,
+L2-normalizes, and **rewrites** FAISS (`index.faiss`: FlatIP until 10k vectors,
+then HNSW). Do not full-rebuild 50k images on every chunk. Fg/bg needs `rembg`
+(U2-Net). `POST /api/clip/reload` picks up the new indexes without restarting
+uvicorn.
+
+Solr itself is fine with several IngestInPlace writers at once. The CLIP
+and fg/bg indexes are not: they rewrite `ids.json`, `vectors.npy`, and
+`index.faiss` as one snapshot. Concurrent `--incremental` jobs take an
+exclusive lock per index directory (`data/clip/.write.lock`,
+`data/fg/.write.lock`) so the second waits, then only encodes ids still
+missing. CLIP and fg/bg use different locks, so those two tasks can still
+overlap.
+
+Manual:
+
+```bash
+IMAGE_SPACE_PYTHON=.venv-embed/bin/python bin/rebuild-clip
+PYTHONPATH=. .venv-embed/bin/python -m server.embed_fgbg --incremental
+```

--- a/imagespace/docs/WHAT-IS-IN.md
+++ b/imagespace/docs/WHAT-IS-IN.md
@@ -1,0 +1,38 @@
+# ImageSpace: what is in, what is out
+
+ImageSpace is the analyst desktop for ImageCat and lives in this RADiX
+tree (`imagespace/`). Solr holds OCR and Tika metadata; this app searches
+it and shows the pictures.
+
+## Keep
+
+- Solr `imagecat` as the catalog (`id`, `ocr_text`, Tika EXIF, `sha1sum_s_md`)
+- Search box = OCR / metadata; `*` = browse
+- Image grid
+- Detective tray of saved images
+- Details: full Tika record + thumbnail; click a field value to search Solr for it
+- Images on disk at the Solr `id` path
+
+## Throw out
+
+- Girder 1.x, Mongo, Jade / Backbone / Grunt
+- Kitware SMQTK (CaffeNet, FLANN, libSVM, IQR Flask)
+- CMU Caffe fg/bg + ScalableLSH
+- OpenCV histogram / Tangelo FLANN server
+- Docker-as-install
+- Columbia / Georgetown / weapons / VideoSpace (not v1)
+
+## Replace
+
+| Was | Is |
+| --- | --- |
+| Girder plugin | Vue 3 + FastAPI |
+| Solr 4 `imagecatdev` | ImageCat Solr 10 `imagecat` |
+| Caffe AlexNet FC7 | HuggingFace CLIP (`openai/clip-vit-base-patch32`, Torch) |
+| FLANN / ITQ-LSH | Cosine over L2-normalized CLIP vectors (numpy; FAISS when the corpus is huge) |
+| SMQTK IQR + libSVM | Tiny Keras head on CLIP vectors |
+| CMU Caffe segmentation | U2-Net (`rembg`) fg/bg CLIP indexes |
+| Girder Private folder | `localStorage` tray |
+
+Vision transformers stay on Torch + HuggingFace, same as ImageCat TrOCR.
+The IQR ranker is a small Keras dense head, not a second vision stack.

--- a/imagespace/docs/roadmap.md
+++ b/imagespace/docs/roadmap.md
@@ -1,0 +1,35 @@
+# ImageSpace / ImageCat roadmap
+
+ImageSpace is the analyst desktop. ImageCat is the ingest pipeline that
+fills Solr and rebuilds CLIP / fg / bg. OPSUI (Mnemosyne) is how we watch
+the jobs.
+
+The product path is in: search, CLIP similar, fg/bg similar, IQR, ingest
+hook, and progress in OPSUI. What follows is the slice map and what is
+parked on purpose.
+
+## Slice / where
+
+| Slice | Where |
+| --- | --- |
+| CLIP/FAISS ingest hook + thumbs | ImageSpace #1, #2 |
+| Field search, FG/BG similar, load-more, clear-X | ImageSpace #3 |
+| Concurrent CLIP/FG-BG write lock | ImageSpace #4 |
+| EXIF filter chips | ImageSpace #5 |
+| `.progress` from CLIP/FG-BG | ImageSpace #6 |
+| Card actions stay on the tile | ImageSpace #7 |
+| IndexImageSpace + IndexImageSpaceFgBg on IngestInPlace | ImageCat #50–#54 |
+| PGE Peek, progress bar, W1 `PGE EXEC` stamp, wall clock | Mnemosyne #262, #265, #270, #256 |
+
+## Live (this checkout)
+
+- Solr `imagecat`, CLIP, fg, and bg indexes: last full re-ingest **666** docs
+- ImageCat stays on W1 `ThreadPoolWorkflowEngineFactory` (do not switch to W2)
+- ImageSpace UI in the distro is FastAPI at **http://127.0.0.1:8090/** (`bin/oodt start`). Vite at **5173** is optional for UI development.
+- DRAT stays on **9000/9001**; ImageCat FM/WM are **9100/9101**
+
+## Parked (not missing ImageSpace features)
+
+- **DRAT `.progress`** — done separately (Claude)
+- **Mnemosyne #267 `ProductCountSettledCondition`** — merged, not wired into ImageCat. A pre-condition on `IndexImageSpace` / `IndexImageSpaceFgBg` that waits until a File Manager product type stops growing. Useful if IngestInPlace is fanned out across chunks and CLIP should not start until the catalog is stable. Today's dynWorkflow is already sequential, and ImageCat's growing catalog for CLIP is Solr `imagecat`, not FM `ChunkList` products, so this stays unwired unless we fan-out ingest.
+- **Mnemosyne #270** — merged; redeploy onto the live ImageCat WM so OPSUI can show `PGE EXEC` instead of `STARTED` while a PGE runs

--- a/imagespace/requirements-embed.txt
+++ b/imagespace/requirements-embed.txt
@@ -1,0 +1,6 @@
+-r requirements.txt
+torch>=2.2.0
+transformers>=4.40.0,<5
+Pillow>=10.0.0
+sentencepiece>=0.2.0
+# Phase 4 fg/bg: pip install rembg onnxruntime

--- a/imagespace/requirements-iqr.txt
+++ b/imagespace/requirements-iqr.txt
@@ -1,0 +1,4 @@
+# Python 3.9+ (Keras 3). The search-only 3.8 venv does not include this.
+-r requirements.txt
+keras>=3.0
+tensorflow>=2.16

--- a/imagespace/requirements.txt
+++ b/imagespace/requirements.txt
@@ -1,0 +1,12 @@
+fastapi>=0.110
+uvicorn[standard]>=0.27
+httpx>=0.27
+numpy>=1.24
+faiss-cpu>=1.8.0
+Pillow>=10.0.0
+# Phase 2 indexer (CLIP). The search server only needs numpy for similar.
+# Install with: pip install -r requirements-embed.txt
+# torch
+# transformers>=4.40.0,<5
+# Pillow>=10.0.0
+# Phase 3 IQR: pip install -r requirements-iqr.txt (Python 3.9+)

--- a/imagespace/server/__init__.py
+++ b/imagespace/server/__init__.py
@@ -1,0 +1,1 @@
+# ImageSpace FastAPI package.

--- a/imagespace/server/config.py
+++ b/imagespace/server/config.py
@@ -1,0 +1,47 @@
+"""Runtime settings. Solr is ImageCat; ids are filesystem paths.
+
+Index files live under ``$OODT_HOME/data/imagespace`` when ImageCat is
+installed. A standalone checkout still uses ``./data`` if OODT_HOME is unset.
+"""
+
+from __future__ import annotations
+
+import os
+
+
+def solr_url() -> str:
+    return os.environ.get("IMAGE_SPACE_SOLR", "http://localhost:8983/solr/imagecat").rstrip("/")
+
+
+def solr_timeout() -> float:
+    return float(os.environ.get("IMAGE_SPACE_SOLR_TIMEOUT", "15"))
+
+
+def data_root() -> str:
+    env = os.environ.get("IMAGE_SPACE_DATA")
+    if env:
+        return env
+    home = os.environ.get("OODT_HOME") or os.environ.get("IMAGECAT_HOME")
+    if home:
+        return os.path.join(home, "data", "imagespace")
+    return "data"
+
+
+def index_dir() -> str:
+    return os.environ.get("IMAGE_SPACE_INDEX_DIR", os.path.join(data_root(), "clip"))
+
+
+def fg_dir() -> str:
+    return os.environ.get("IMAGE_SPACE_FG_DIR", os.path.join(data_root(), "fg"))
+
+
+def bg_dir() -> str:
+    return os.environ.get("IMAGE_SPACE_BG_DIR", os.path.join(data_root(), "bg"))
+
+
+def thumb_dir() -> str:
+    return os.environ.get("IMAGE_SPACE_THUMB_DIR", os.path.join(data_root(), "thumbs"))
+
+
+def clip_model() -> str:
+    return os.environ.get("IMAGE_SPACE_CLIP_MODEL", "openai/clip-vit-base-patch32")

--- a/imagespace/server/embed.py
+++ b/imagespace/server/embed.py
@@ -1,0 +1,154 @@
+"""Encode ImageCat Solr images with CLIP. Query time does not load this module.
+
+    PYTHONPATH=. python -m server.embed
+    PYTHONPATH=. python -m server.embed --incremental
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+from . import solr
+from .config import clip_model, index_dir
+from .index_lock import exclusive_index
+from .progress import write_progress
+from .similar import IDS_NAME, VEC_NAME, save_index
+
+
+def encode_paths(paths: list[str], model_name: str, progress_msg: str = "encoded"):
+    import numpy as np
+    import torch
+    from PIL import Image, ImageFile, ImageOps
+
+    ImageFile.LOAD_TRUNCATED_IMAGES = True
+    from transformers import CLIPModel, CLIPProcessor
+
+    processor = CLIPProcessor.from_pretrained(model_name)
+    model = CLIPModel.from_pretrained(model_name)
+    model.eval()
+    # MPS + huge JPEGs has segfaulted here; CLIP is 224px, CPU is enough.
+    device = torch.device("cpu")
+    model.to(device)
+    rows = []
+    kept = []
+    n = len(paths)
+    if n:
+        write_progress(0, n, progress_msg)
+    with torch.no_grad():
+        for i, path in enumerate(paths):
+            try:
+                image = Image.open(path)
+                image = ImageOps.exif_transpose(image).convert("RGB")
+                image.thumbnail((512, 512))
+                inputs = processor(images=image, return_tensors="pt")
+                inputs = {k: v.to(device) for k, v in inputs.items()}
+                feat = model.get_image_features(**inputs)
+                rows.append(feat[0].cpu().numpy())
+                kept.append(path)
+            except Exception as exc:
+                print("skip encode %s: %s" % (path, exc), file=sys.stderr)
+            if (i + 1) % 50 == 0 or (i + 1) == n:
+                write_progress(i + 1, n, progress_msg)
+                print("encoded %d / %d" % (i + 1, n))
+    if not rows:
+        return kept, np.zeros((0, 512), dtype="float32")
+    return kept, np.stack(rows, axis=0)
+
+
+def collect_paths():
+    out = []
+    for doc in solr.iter_docs("id,sha1sum_s_md"):
+        doc_id = doc.get("id")
+        if not doc_id:
+            continue
+        path = Path(doc_id)
+        if path.is_file():
+            out.append(doc_id)
+        else:
+            print("skip missing file: %s" % doc_id, file=sys.stderr)
+    return out
+
+
+def load_existing(folder: Path):
+    import numpy as np
+
+    ids_path = folder / IDS_NAME
+    vec_path = folder / VEC_NAME
+    if not ids_path.is_file() or not vec_path.is_file():
+        return [], np.zeros((0, 512), dtype="float32")
+    return json.loads(ids_path.read_text()), np.load(vec_path)
+
+
+def main(argv=None) -> int:
+    parser = argparse.ArgumentParser(description="Encode ImageCat Solr images with CLIP.")
+    parser.add_argument(
+        "--incremental",
+        action="store_true",
+        help="Only encode Solr ids not already in the index (for ImageCat ingest).",
+    )
+    parser.add_argument(
+        "--reload-url",
+        default="http://127.0.0.1:8090/api/clip/reload",
+        help="POST here after writing the index so ImageSpace picks it up.",
+    )
+    parser.add_argument("--no-reload", action="store_true", help="Do not POST reload.")
+    args = parser.parse_args(argv)
+
+    model_name = clip_model()
+    folder = Path(index_dir())
+    print("Solr images -> CLIP [%s] -> %s" % (model_name, folder))
+    # Hold the directory lock across load + encode + save so a second
+    # IngestInPlace incremental waits, then sees this write, instead of
+    # both rewriting ids.json / vectors.npy / index.faiss.
+    with exclusive_index(folder):
+        return _build(args, folder, model_name)
+
+
+def _build(args, folder: Path, model_name: str) -> int:
+    paths = collect_paths()
+    existing_ids, existing_vectors = load_existing(folder) if args.incremental else ([], None)
+    existing = set(existing_ids)
+    todo = [p for p in paths if p not in existing] if args.incremental else paths
+    print("files: %d  already indexed: %d  to encode: %d" % (len(paths), len(existing), len(todo)))
+    if args.incremental and not todo:
+        print("index already covers Solr")
+        _reload(args)
+        return 0
+    if not args.incremental and len(todo) < 2:
+        print("Need at least two on-disk images to build a similarity index.", file=sys.stderr)
+        return 2
+    new_ids, new_vectors = encode_paths(todo, model_name)
+    import numpy as np
+
+    if args.incremental and len(existing_ids):
+        ids = existing_ids + new_ids
+        vectors = np.concatenate([existing_vectors, new_vectors], axis=0) if len(new_ids) else existing_vectors
+    else:
+        ids, vectors = new_ids, new_vectors
+    if len(ids) < 2:
+        print("Need at least two on-disk images to build a similarity index.", file=sys.stderr)
+        return 2
+    save_index(ids, vectors, {"model": model_name, "count": len(ids), "dim": int(vectors.shape[1])}, folder)
+    print("wrote %d vectors dim %d" % (len(ids), int(vectors.shape[1])))
+    _reload(args)
+    return 0
+
+
+def _reload(args) -> None:
+    if args.no_reload:
+        return
+    try:
+        import urllib.request
+
+        req = urllib.request.Request(args.reload_url, method="POST", data=b"")
+        with urllib.request.urlopen(req, timeout=10) as response:
+            print("reload", response.status, response.read().decode()[:200])
+    except Exception as exc:
+        print("index written; reload ImageSpace later (%s)" % exc, file=sys.stderr)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/imagespace/server/embed_fgbg.py
+++ b/imagespace/server/embed_fgbg.py
@@ -1,0 +1,112 @@
+"""Encode ImageCat images as CLIP foreground and background indexes.
+
+    PYTHONPATH=. python -m server.embed_fgbg --incremental
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+from . import solr
+from .config import bg_dir, clip_model, fg_dir
+from .embed import _reload, collect_paths, encode_paths, load_existing
+from .progress import write_progress
+from .index_lock import exclusive_index
+from .segment import rembg_available, split_fg_bg
+from .similar import save_index
+
+
+def encode_split(paths: list[str], model_name: str):
+    import tempfile
+
+    fg_paths = []
+    bg_paths = []
+    kept = []
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        n = len(paths)
+        if n:
+            write_progress(0, n, "split")
+        for i, path in enumerate(paths):
+            try:
+                fg, bg = split_fg_bg(path)
+                fg_file = root / ("fg-%d.jpg" % i)
+                bg_file = root / ("bg-%d.jpg" % i)
+                fg.save(fg_file, quality=90)
+                bg.save(bg_file, quality=90)
+                fg_paths.append(str(fg_file))
+                bg_paths.append(str(bg_file))
+                kept.append(path)
+            except Exception as exc:
+                print("skip fg/bg %s: %s" % (path, exc), file=sys.stderr)
+            if (i + 1) % 25 == 0 or (i + 1) == n:
+                write_progress(i + 1, n, "split")
+                print("split %d / %d" % (i + 1, n))
+        if not kept:
+            import numpy as np
+
+            empty = np.zeros((0, 512), dtype="float32")
+            return [], empty, empty
+        _, fg_vec = encode_paths(fg_paths, model_name, progress_msg="fg CLIP")
+        _, bg_vec = encode_paths(bg_paths, model_name, progress_msg="bg CLIP")
+    return kept, fg_vec, bg_vec
+
+
+def _write_side(existing_ids, existing_vectors, new_ids, new_vectors, folder, model_name):
+    import numpy as np
+
+    if existing_ids:
+        all_ids = existing_ids + new_ids
+        vectors = np.concatenate([existing_vectors, new_vectors], axis=0) if len(new_ids) else existing_vectors
+    else:
+        all_ids, vectors = new_ids, new_vectors
+    if len(all_ids) < 2:
+        raise SystemExit("Need at least two fg/bg vectors")
+    save_index(all_ids, vectors, {"model": model_name, "count": len(all_ids), "dim": int(vectors.shape[1]), "space": folder.name}, folder)
+    print("wrote %s %d vectors" % (folder, len(all_ids)))
+
+
+def main(argv=None) -> int:
+    parser = argparse.ArgumentParser(description="Encode CLIP foreground and background indexes.")
+    parser.add_argument("--incremental", action="store_true")
+    parser.add_argument("--reload-url", default="http://127.0.0.1:8090/api/clip/reload")
+    parser.add_argument("--no-reload", action="store_true")
+    parser.add_argument("--limit", type=int, default=0, help="Encode at most N new images (0 = all).")
+    args = parser.parse_args(argv)
+    if not rembg_available():
+        print("rembg is not installed. pip install rembg onnxruntime", file=sys.stderr)
+        return 2
+    model_name = clip_model()
+    fg_folder = Path(fg_dir())
+    bg_folder = Path(bg_dir())
+    # One lock for both sides: they are always rewritten together. CLIP
+    # uses data/clip/.write.lock, so a CLIP incremental can still run
+    # while this waits or holds data/fg/.write.lock.
+    with exclusive_index(fg_folder):
+        return _build(args, fg_folder, bg_folder, model_name)
+
+
+def _build(args, fg_folder: Path, bg_folder: Path, model_name: str) -> int:
+    paths = collect_paths()
+    existing_fg_ids, existing_fg = load_existing(fg_folder) if args.incremental else ([], None)
+    existing = set(existing_fg_ids)
+    todo = [p for p in paths if p not in existing] if args.incremental else paths
+    if args.limit and args.limit > 0:
+        todo = todo[: args.limit]
+    print("fg/bg CLIP [%s] files=%d already=%d todo=%d" % (model_name, len(paths), len(existing), len(todo)))
+    if args.incremental and not todo:
+        print("fg/bg index already covers Solr")
+        _reload(args)
+        return 0
+    new_ids, fg_vec, bg_vec = encode_split(todo, model_name)
+    _write_side(existing_fg_ids, existing_fg, new_ids, fg_vec, fg_folder, model_name)
+    existing_bg_ids, existing_bg = load_existing(bg_folder) if args.incremental else ([], None)
+    _write_side(existing_bg_ids, existing_bg, new_ids, bg_vec, bg_folder, model_name)
+    _reload(args)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/imagespace/server/images.py
+++ b/imagespace/server/images.py
@@ -1,0 +1,65 @@
+"""Serve image bytes only when Solr has that id. Not a general file server.
+
+Grid tiles use ?w=360 so the browser is not decoding 10MB originals.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import mimetypes
+from pathlib import Path
+
+from fastapi import HTTPException
+from fastapi.responses import FileResponse
+
+from . import solr
+from .config import thumb_dir
+
+_ALLOWED = {".jpg", ".jpeg", ".png", ".gif", ".webp", ".tif", ".tiff", ".bmp"}
+_THUMB_MAX = 1600
+_THUMB_MIN = 32
+
+
+def _scalar(value):
+    if isinstance(value, list) and value:
+        return value[0]
+    return value
+
+
+def _resolved(doc_id: str) -> Path:
+    doc = solr.get_doc(doc_id)
+    if doc is None:
+        raise HTTPException(status_code=404, detail="No Solr document for that id")
+    path = Path(doc_id)
+    if not path.is_absolute() or not path.is_file():
+        raise HTTPException(status_code=404, detail="Image file is not on this host")
+    if path.suffix.lower() not in _ALLOWED:
+        raise HTTPException(status_code=415, detail="Not an image suffix")
+    return path
+
+
+def make_thumb(src: Path, dest: Path, width: int) -> None:
+    from PIL import Image, ImageFile, ImageOps
+
+    ImageFile.LOAD_TRUNCATED_IMAGES = True
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    image = Image.open(src)
+    image = ImageOps.exif_transpose(image).convert("RGB")
+    image.thumbnail((width, width), Image.Resampling.LANCZOS)
+    tmp = dest.with_suffix(".tmp.jpg")
+    image.save(tmp, format="JPEG", quality=80, optimize=True)
+    tmp.replace(dest)
+
+
+def file_response(doc_id: str, width: int | None = None) -> FileResponse:
+    path = _resolved(doc_id)
+    media = mimetypes.guess_type(str(path))[0] or "application/octet-stream"
+    headers = {"Cache-Control": "public, max-age=86400"}
+    if not width:
+        return FileResponse(path, media_type=media, headers=headers)
+    width = max(_THUMB_MIN, min(int(width), _THUMB_MAX))
+    key = hashlib.sha1(("%s:%d" % (doc_id, width)).encode("utf-8")).hexdigest()
+    cache = Path(thumb_dir()) / (key + ".jpg")
+    if not cache.is_file() or cache.stat().st_mtime < path.stat().st_mtime:
+        make_thumb(path, cache, width)
+    return FileResponse(cache, media_type="image/jpeg", headers=headers)

--- a/imagespace/server/index_lock.py
+++ b/imagespace/server/index_lock.py
@@ -1,0 +1,39 @@
+"""Exclusive lock for CLIP / fg / bg index writes.
+
+Solr can take concurrent IngestInPlace writers. The similarity indexes
+are files (ids.json, vectors.npy, index.faiss) rewritten as one snapshot.
+Two --incremental jobs without a lock both load the same ids, encode
+overlapping images, and the last save_index wins — dropping the other
+job's vectors.
+
+fcntl.LOCK_EX serializes those jobs per index directory. CLIP (data/clip)
+and fg/bg (data/fg) use different lock files, so they can still run at the
+same time. A second CLIP ingest waits, then sees the updated ids and only
+encodes what is still missing.
+"""
+
+from __future__ import annotations
+
+import fcntl
+import sys
+from contextlib import contextmanager
+from pathlib import Path
+
+LOCK_NAME = ".write.lock"
+
+
+@contextmanager
+def exclusive_index(folder: str | Path):
+    path = Path(folder)
+    path.mkdir(parents=True, exist_ok=True)
+    handle = open(path / LOCK_NAME, "a+")
+    try:
+        try:
+            fcntl.flock(handle.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except BlockingIOError:
+            print("waiting for index lock on %s" % path, file=sys.stderr)
+            fcntl.flock(handle.fileno(), fcntl.LOCK_EX)
+        yield path
+    finally:
+        fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+        handle.close()

--- a/imagespace/server/iqr.py
+++ b/imagespace/server/iqr.py
@@ -1,0 +1,105 @@
+"""Tiny Keras head for Interactive Query Refinement.
+
+CLIP vectors stay on disk. This ranker maps a CLIP vector to P(relevant).
+"""
+
+from __future__ import annotations
+
+from functools import lru_cache
+
+DEFAULT_DIM = 512
+
+
+@lru_cache(maxsize=1)
+def keras_available() -> bool:
+    try:
+        import keras  # noqa: F401
+        return True
+    except Exception:
+        try:
+            import tensorflow  # noqa: F401
+            return True
+        except Exception:
+            return False
+
+
+def _layers():
+    try:
+        from keras import Sequential, layers
+        return Sequential, layers
+    except Exception:
+        from tensorflow.keras import Sequential, layers
+        return Sequential, layers
+
+
+def build_head(dim: int = DEFAULT_DIM):
+    Sequential, layers = _layers()
+    if dim < 1:
+        raise ValueError("dim must be positive")
+    return Sequential(
+        [
+            layers.Input(shape=(dim,)),
+            layers.Dense(64, activation="relu", name="iqr_hidden"),
+            layers.Dense(1, activation="sigmoid", name="iqr_relevant"),
+        ],
+        name="iqr_head",
+    )
+
+
+def fit_head(vectors, labels, dim: int = DEFAULT_DIM, epochs: int = 40):
+    import numpy as np
+
+    model = build_head(dim)
+    model.compile(optimizer="adam", loss="binary_crossentropy")
+    x = np.asarray(vectors, dtype="float32")
+    y = np.asarray(labels, dtype="float32").reshape((-1, 1))
+    batch = max(1, min(8, len(x)))
+    model.fit(x, y, epochs=epochs, batch_size=batch, verbose=0)
+    return model
+
+
+def score_vectors(model, vectors):
+    import numpy as np
+
+    x = np.asarray(vectors, dtype="float32")
+    raw = model.predict(x, verbose=0)
+    return np.asarray(raw, dtype="float32").reshape(-1)
+
+
+def refine(index, positive_ids, negative_ids, n: int = 24):
+    """Fit the head on pos/neg CLIP rows and rank the whole index."""
+    pos = []
+    neg = []
+    seen_pos = set()
+    seen_neg = set()
+    for doc_id in positive_ids or []:
+        row = index.row(doc_id)
+        if row is None or doc_id in seen_pos:
+            continue
+        seen_pos.add(doc_id)
+        pos.append(row)
+    for doc_id in negative_ids or []:
+        if doc_id in seen_pos:
+            continue
+        row = index.row(doc_id)
+        if row is None or doc_id in seen_neg:
+            continue
+        seen_neg.add(doc_id)
+        neg.append(row)
+    if not pos or not neg:
+        raise ValueError("IQR needs at least one relevant and one not-relevant image in the CLIP index")
+    import numpy as np
+
+    rows = pos + neg
+    labels = [1.0] * len(pos) + [0.0] * len(neg)
+    vectors = index.vectors[np.array(rows)]
+    dim = int(index.vectors.shape[1])
+    model = fit_head(vectors, labels, dim=dim)
+    scores = score_vectors(model, index.vectors)
+    order = np.argsort(-scores)
+    n = max(1, min(int(n), len(index.ids)))
+    hits = []
+    for j in order[:n]:
+        j = int(j)
+        hits.append({"id": index.ids[j], "iqr_score": float(scores[j])})
+    return hits, {"positive": len(pos), "negative": len(neg), "scored": len(index.ids)}

--- a/imagespace/server/main.py
+++ b/imagespace/server/main.py
@@ -1,0 +1,186 @@
+"""ImageSpace HTTP API. Search, CLIP similar, IQR refine."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from fastapi import FastAPI, HTTPException, Query
+from fastapi.middleware.cors import CORSMiddleware
+from fastapi.staticfiles import StaticFiles
+from pydantic import BaseModel, Field
+
+from . import images, iqr, solr
+from .config import bg_dir, fg_dir
+from .similar import ClipIndex
+
+app = FastAPI(title="ImageSpace", version="0.1.0")
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["http://localhost:5173", "http://127.0.0.1:5173"],
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+_UI_DIST = Path(__file__).resolve().parents[1] / "web" / "dist"
+
+class IqrRefineBody(BaseModel):
+    positive: list[str] = Field(default_factory=list)
+    negative: list[str] = Field(default_factory=list)
+    n: int = 24
+
+
+_clip = ClipIndex()
+_fg = ClipIndex(fg_dir())
+_bg = ClipIndex(bg_dir())
+
+
+def _index() -> ClipIndex:
+    if not _clip.available():
+        _clip.reload()
+    return _clip
+
+
+def _space(name: str | None) -> ClipIndex:
+    key = (name or "clip").lower()
+    if key == "fg":
+        if not _fg.available():
+            _fg.reload()
+        return _fg
+    if key == "bg":
+        if not _bg.available():
+            _bg.reload()
+        return _bg
+    return _index()
+
+
+@app.get("/api/health")
+def health():
+    ping = solr.ping()
+    index = _index()
+    ping["capabilities"] = {
+        "search": True,
+        "similar": index.available(),
+        "iqr": index.available() and iqr.keras_available(),
+        "fgbg": _fg.available() and _bg.available(),
+    }
+    if index.available():
+        ping["clip"] = {
+            "count": len(index.ids),
+            "model": index.meta.get("model"),
+            "dim": index.meta.get("dim"),
+            "backend": index.meta.get("backend"),
+            "faiss": index.meta.get("faiss"),
+        }
+    return ping
+
+
+def _mark_indexes(docs: list) -> None:
+    clip = _index()
+    fg = _space("fg")
+    bg = _space("bg")
+    for doc in docs:
+        doc_id = doc.get("id")
+        doc["clip_indexed"] = clip.row(doc_id) is not None if clip.available() else False
+        doc["fg_indexed"] = fg.row(doc_id) is not None if fg.available() else False
+        doc["bg_indexed"] = bg.row(doc_id) is not None if bg.available() else False
+
+
+@app.get("/api/search")
+def search(
+    q: str = Query("*"),
+    start: int = Query(0),
+    rows: int = Query(24),
+    fq: list[str] | None = Query(None),
+):
+    try:
+        body = solr.search(q, start, rows, fq or [])
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    _mark_indexes(body.get("docs") or [])
+    return body
+
+
+@app.get("/api/doc")
+def doc(id: str = Query(...)):
+    found = solr.get_doc(id)
+    if found is None:
+        return {"missing": True, "id": id}
+    _mark_indexes([found])
+    return {"doc": found}
+
+
+@app.get("/api/file")
+def file(id: str = Query(...), w: int | None = Query(None)):
+    return images.file_response(id, w)
+
+
+@app.get("/api/similar")
+def similar(id: str = Query(...), n: int = Query(24), space: str = Query("clip")):
+    index = _space(space)
+    label = (space or "clip").lower()
+    if label in ("fg", "bg"):
+        missing = "Foreground/background index is not built. Run python -m server.embed_fgbg"
+    else:
+        missing = "CLIP index is not built. Run python -m server.embed"
+    if not index.available():
+        raise HTTPException(status_code=503, detail=missing)
+    hits = index.similar(id, n)
+    if hits is None:
+        raise HTTPException(status_code=404, detail="That image is not in the %s index" % (label if label in ("fg", "bg") else "CLIP"))
+    docs = solr.get_docs([h["id"] for h in hits])
+    scores = {h["id"]: h["clip_score"] for h in hits}
+    for doc in docs:
+        doc["clip_score"] = scores.get(doc.get("id"))
+    _mark_indexes(docs)
+    available = max(0, len(index.ids) - 1)
+    return {
+        "id": id,
+        "numFound": available,
+        "docs": docs,
+    }
+
+
+@app.post("/api/iqr/refine")
+def iqr_refine(body: IqrRefineBody):
+    index = _index()
+    if not index.available():
+        raise HTTPException(status_code=503, detail="CLIP index is not built. Run python -m server.embed")
+    if not iqr.keras_available():
+        raise HTTPException(status_code=503, detail="Keras is not installed (IQR head)")
+    try:
+        hits, stats = iqr.refine(index, body.positive, body.negative, body.n)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    docs = solr.get_docs([h["id"] for h in hits])
+    scores = {h["id"]: h["iqr_score"] for h in hits}
+    for doc in docs:
+        doc["iqr_score"] = scores.get(doc.get("id"))
+    _mark_indexes(docs)
+    return {
+        "numFound": int((stats or {}).get("scored") or len(docs)),
+        "docs": docs,
+        "stats": stats,
+    }
+
+
+@app.post("/api/clip/reload")
+def clip_reload():
+    """Called after python -m server.embed (and from the ImageCat ingest hook)."""
+    _clip.reload()
+    _fg.reload()
+    _bg.reload()
+    index = _clip
+    return {
+        "ok": index.available(),
+        "count": len(index.ids),
+        "backend": index.meta.get("backend"),
+        "model": index.meta.get("model"),
+        "fg": len(_fg.ids),
+        "bg": len(_bg.ids),
+    }
+
+
+# Built Vue (npm run build) is served from the same process as /api. Vite
+# on 5173 is still fine for development. Register last so /api wins.
+if _UI_DIST.is_dir():
+    app.mount("/", StaticFiles(directory=str(_UI_DIST), html=True), name="ui")

--- a/imagespace/server/progress.py
+++ b/imagespace/server/progress.py
@@ -1,0 +1,24 @@
+"""PGE .progress file for OPSUI. Opt-in: scripts that never call this have no bar."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+
+def progress_dir(folder: str | Path | None = None) -> Path:
+    if folder:
+        return Path(folder)
+    env = os.environ.get("PGE_PROGRESS_DIR")
+    if env:
+        return Path(env)
+    return Path(".")
+
+
+def write_progress(done: int, total: int, msg: str = "encoded", folder: str | Path | None = None) -> Path:
+    path = progress_dir(folder) / ".progress"
+    path.write_text(
+        "done=%d\ntotal=%d\nmsg=%s\n" % (int(done), int(total), msg or ""),
+        encoding="utf-8",
+    )
+    return path

--- a/imagespace/server/segment.py
+++ b/imagespace/server/segment.py
@@ -1,0 +1,40 @@
+"""Split an image into foreground / background stills for CLIP.
+
+Uses rembg (U2-Net). The search server does not load this module.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from PIL import Image, ImageFile, ImageOps
+
+ImageFile.LOAD_TRUNCATED_IMAGES = True
+
+GRAY = (128, 128, 128)
+
+
+def rembg_available() -> bool:
+    try:
+        import rembg  # noqa: F401
+        return True
+    except Exception:
+        return False
+
+
+def split_fg_bg(path: str | Path, size: int = 768):
+    from rembg import remove
+
+    image = Image.open(path)
+    image = ImageOps.exif_transpose(image).convert("RGB")
+    image.thumbnail((size, size))
+    cut = remove(image)
+    if cut.mode != "RGBA":
+        cut = cut.convert("RGBA")
+    alpha = cut.split()[-1]
+    fg = Image.new("RGB", image.size, GRAY)
+    fg.paste(cut, mask=alpha)
+    inv = Image.eval(alpha, lambda p: 255 - p)
+    bg = Image.new("RGB", image.size, GRAY)
+    bg.paste(image, mask=inv)
+    return fg, bg

--- a/imagespace/server/similar.py
+++ b/imagespace/server/similar.py
@@ -1,0 +1,130 @@
+"""FAISS nearest neighbors over L2-normalized CLIP vectors. No Torch at query time."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import numpy as np
+
+from .config import index_dir
+
+IDS_NAME = "ids.json"
+VEC_NAME = "vectors.npy"
+META_NAME = "meta.json"
+FAISS_NAME = "index.faiss"
+# Exact inner product until the catalog is large; then HNSW.
+HNSW_AFTER = 10_000
+
+def _faiss():
+    try:
+        import faiss
+        return faiss
+    except ImportError:
+        return None
+
+
+def _dir() -> Path:
+    return Path(index_dir())
+
+
+def build_faiss(vectors: np.ndarray):
+    faiss = _faiss()
+    if faiss is None:
+        raise RuntimeError("faiss-cpu is not installed")
+    n, dim = vectors.shape
+    if n >= HNSW_AFTER:
+        index = faiss.IndexHNSWFlat(dim, 32, faiss.METRIC_INNER_PRODUCT)
+        index.hnsw.efConstruction = 80
+        index.hnsw.efSearch = 64
+    else:
+        index = faiss.IndexFlatIP(dim)
+    index.add(vectors)
+    return index
+
+
+class ClipIndex:
+    def __init__(self, directory: str | Path | None = None):
+        self.directory = Path(directory) if directory else _dir()
+        self.ids: list[str] = []
+        self.id_to_row: dict[str, int] = {}
+        self.vectors: np.ndarray | None = None
+        self.faiss = None
+        self.meta: dict = {}
+        self.reload()
+
+    def reload(self) -> None:
+        ids_path = self.directory / IDS_NAME
+        vec_path = self.directory / VEC_NAME
+        meta_path = self.directory / META_NAME
+        faiss_path = self.directory / FAISS_NAME
+        self.faiss = None
+        if not ids_path.is_file() or not vec_path.is_file():
+            self.ids = []
+            self.id_to_row = {}
+            self.vectors = None
+            self.meta = {}
+            return
+        self.ids = json.loads(ids_path.read_text())
+        self.vectors = np.load(vec_path)
+        self.meta = json.loads(meta_path.read_text()) if meta_path.is_file() else {}
+        if len(self.ids) != int(self.vectors.shape[0]):
+            raise ValueError("CLIP index ids and vectors are different lengths")
+        self.id_to_row = {doc_id: i for i, doc_id in enumerate(self.ids)}
+        faiss = _faiss()
+        if faiss is not None:
+            if faiss_path.is_file():
+                self.faiss = faiss.read_index(str(faiss_path))
+            else:
+                self.faiss = build_faiss(self.vectors)
+        self.meta["backend"] = "faiss" if self.faiss is not None else "numpy"
+
+    def available(self) -> bool:
+        return self.vectors is not None and len(self.ids) > 1
+
+    def row(self, doc_id: str) -> int | None:
+        return self.id_to_row.get(doc_id)
+
+    def similar(self, doc_id: str, n: int = 24) -> list[dict] | None:
+        if not self.available():
+            return None
+        idx = self.row(doc_id)
+        if idx is None:
+            return None
+        n = max(1, min(int(n), len(self.ids) - 1))
+        k = n + 1
+        if self.faiss is not None:
+            scores, rows = self.faiss.search(self.vectors[idx : idx + 1], k)
+            scored_rows = [(int(rows[0][i]), float(scores[0][i])) for i in range(len(rows[0])) if rows[0][i] >= 0]
+        else:
+            all_scores = self.vectors @ self.vectors[idx]
+            order = np.argsort(-all_scores)[:k]
+            scored_rows = [(int(j), float(all_scores[int(j)])) for j in order]
+        out = []
+        for j, score in scored_rows:
+            if j == idx:
+                continue
+            out.append({"id": self.ids[j], "clip_score": score})
+            if len(out) >= n:
+                break
+        return out
+
+
+def save_index(ids: list[str], vectors: np.ndarray, meta: dict, directory: str | Path | None = None) -> Path:
+    folder = Path(directory) if directory else _dir()
+    folder.mkdir(parents=True, exist_ok=True)
+    if vectors.dtype != np.float32:
+        vectors = vectors.astype(np.float32)
+    norms = np.linalg.norm(vectors, axis=1, keepdims=True)
+    norms[norms == 0] = 1.0
+    vectors = vectors / norms
+    np.save(folder / VEC_NAME, vectors)
+    (folder / IDS_NAME).write_text(json.dumps(ids))
+    faiss = _faiss()
+    if faiss is not None:
+        faiss.write_index(build_faiss(vectors), str(folder / FAISS_NAME))
+        meta = dict(meta)
+        meta["backend"] = "faiss"
+        meta["faiss"] = "HNSW" if len(ids) >= HNSW_AFTER else "FlatIP"
+    (folder / META_NAME).write_text(json.dumps(meta, indent=2))
+    return folder

--- a/imagespace/server/solr.py
+++ b/imagespace/server/solr.py
@@ -1,0 +1,232 @@
+"""Query ImageCat Solr. Document id is the original image path."""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+from urllib.parse import quote
+
+import httpx
+
+from .config import solr_timeout, solr_url
+
+HIDDEN = {"_version_", "_root_", "text", "text_rev"}
+SKIP_FIELD_SEARCH = HIDDEN | {"highlight", "clip_score", "iqr_score"}
+_FIELD_QUERY = re.compile(r"^[A-Za-z_][\w.]*:")
+_FIELD_CLAUSE = re.compile(r"^([A-Za-z_][\w.]*)\s*:\s*(.*)$")
+
+
+def user_query(raw: str | None) -> str:
+    q = (raw or "").strip()
+    if not q or q == "*":
+        return "*:*"
+    return q
+
+
+def is_field_query(raw: str | None) -> bool:
+    q = (raw or "").strip()
+    return bool(_FIELD_QUERY.match(q))
+
+
+def field_query(field: str, value: Any) -> str:
+    """Build a Solr clause that matches one Tika/OCR field value."""
+    name = re.sub(r"[^\w.]", "", str(field or ""))
+    if not name or name in SKIP_FIELD_SEARCH:
+        raise ValueError("that field is not searchable")
+    if value is None or value == "":
+        raise ValueError("empty value")
+    text = str(value).strip()
+    if not text:
+        raise ValueError("empty value")
+    escaped = text.replace("\\", "\\\\").replace('"', '\\"')
+    return '%s:"%s"' % (name, escaped)
+
+
+def _unescape_solr_quoted(text: str) -> str:
+    out: list[str] = []
+    i = 0
+    while i < len(text):
+        if text[i] == "\\" and i + 1 < len(text):
+            out.append(text[i + 1])
+            i += 2
+        else:
+            out.append(text[i])
+            i += 1
+    return "".join(out)
+
+
+def parse_field_clause(raw: str) -> tuple[str, str]:
+    """Split a chip like tiff_Make:\"Canon\" into field and value."""
+    match = _FIELD_CLAUSE.match((raw or "").strip())
+    if not match:
+        raise ValueError("not a field filter")
+    name, rest = match.group(1), match.group(2).strip()
+    if len(rest) >= 2 and rest[0] == '"' and rest[-1] == '"':
+        rest = _unescape_solr_quoted(rest[1:-1])
+    if not rest:
+        raise ValueError("empty value")
+    return name, rest
+
+
+def filter_queries(raws: list[str] | None) -> list[str]:
+    """Rebuild operator-facing chips as Solr fq clauses."""
+    out: list[str] = []
+    seen: set[str] = set()
+    for raw in raws or []:
+        name, value = parse_field_clause(raw)
+        clause = field_query(name, value)
+        if clause not in seen:
+            seen.add(clause)
+            out.append(clause)
+    return out
+
+
+def _get(path: str, params: dict[str, Any]) -> dict[str, Any]:
+    url = solr_url() + path
+    with httpx.Client(timeout=solr_timeout()) as client:
+        response = client.get(url, params=params)
+        response.raise_for_status()
+        return response.json()
+
+
+def search_params(
+    q: str, start: int = 0, rows: int = 24, filters: list[str] | None = None
+) -> dict[str, Any]:
+    start = max(0, int(start))
+    rows = min(100, max(1, int(rows)))
+    parsed = user_query(q)
+    clauses = filter_queries(filters)
+    params: dict[str, Any] = {
+        "q": parsed,
+        "start": start,
+        "rows": rows,
+        "wt": "json",
+        "hl": "true",
+        "hl.fl": "ocr_text",
+    }
+    if clauses:
+        params["fq"] = clauses
+        params["sort"] = "id asc"
+    if is_field_query(q):
+        params["defType"] = "lucene"
+        params["sort"] = "id asc"
+    else:
+        params["defType"] = "edismax"
+        params["qf"] = "ocr_text text caption"
+        params["q.op"] = "AND"
+    return params
+
+
+def search(
+    q: str, start: int = 0, rows: int = 24, filters: list[str] | None = None
+) -> dict[str, Any]:
+    params = search_params(q, start, rows, filters)
+    body = _get("/select", params)
+    docs = []
+    highlighting = (body.get("highlighting") or {})
+    for doc in (body.get("response") or {}).get("docs") or []:
+        item = {k: v for k, v in doc.items() if k not in HIDDEN}
+        hid = highlighting.get(doc.get("id") or "", {})
+        if hid:
+            item["highlight"] = hid
+        docs.append(item)
+    response = body.get("response") or {}
+    return {
+        "query": params["q"],
+        "filters": list(params.get("fq") or []),
+        "start": int(params["start"]),
+        "rows": int(params["rows"]),
+        "numFound": int(response.get("numFound") or 0),
+        "docs": docs,
+    }
+
+
+def scalar(value: Any) -> Any:
+    if isinstance(value, list) and value:
+        return value[0]
+    return value
+
+
+def iter_docs(fl: str = "id,sha1sum_s_md", page: int = 100):
+    """Yield Solr docs for the whole core."""
+    start = 0
+    while True:
+        body = _get(
+            "/select",
+            {
+                "q": "*:*",
+                "fl": fl,
+                "start": start,
+                "rows": page,
+                "wt": "json",
+                "sort": "id asc",
+            },
+        )
+        docs = (body.get("response") or {}).get("docs") or []
+        if not docs:
+            return
+        for doc in docs:
+            yield doc
+        start += len(docs)
+        total = int((body.get("response") or {}).get("numFound") or 0)
+        if start >= total:
+            return
+
+
+def get_docs(ids: list[str]) -> list[dict[str, Any]]:
+    """Hydrate Solr docs, preserving the given id order."""
+    wanted = [i for i in ids if i]
+    if not wanted:
+        return []
+    by_id: dict[str, dict[str, Any]] = {}
+    chunk = 40
+    for i in range(0, len(wanted), chunk):
+        part = wanted[i : i + chunk]
+        clauses = ['id:"%s"' % doc_id.replace('"', r"\"") for doc_id in part]
+        body = _get(
+            "/select",
+            {
+                "q": " OR ".join(clauses),
+                "rows": len(part),
+                "wt": "json",
+            },
+        )
+        for doc in (body.get("response") or {}).get("docs") or []:
+            item = {k: v for k, v in doc.items() if k not in HIDDEN}
+            if item.get("id"):
+                by_id[item["id"]] = item
+    return [by_id[doc_id] for doc_id in wanted if doc_id in by_id]
+
+
+def get_doc(doc_id: str) -> dict[str, Any] | None:
+    if not doc_id:
+        return None
+    body = _get(
+        "/select",
+        {
+            "q": 'id:"%s"' % doc_id.replace('"', r"\""),
+            "rows": 1,
+            "wt": "json",
+        },
+    )
+    docs = (body.get("response") or {}).get("docs") or []
+    if not docs:
+        return None
+    return {k: v for k, v in docs[0].items() if k not in HIDDEN}
+
+
+def ping() -> dict[str, Any]:
+    try:
+        body = _get("/admin/ping", {"wt": "json"})
+        status = body.get("status") or "unknown"
+    except Exception as exc:
+        return {"ok": False, "solr": solr_url(), "error": str(exc)}
+    try:
+        found = search("*", 0, 0)["numFound"]
+    except Exception:
+        found = None
+    return {"ok": status == "OK", "solr": solr_url(), "status": status, "numFound": found}
+
+
+def file_url(doc_id: str) -> str:
+    return "/api/file?id=" + quote(doc_id, safe="")

--- a/imagespace/tests/test_index_lock.py
+++ b/imagespace/tests/test_index_lock.py
@@ -1,0 +1,56 @@
+import os
+import subprocess
+import sys
+import tempfile
+import time
+import unittest
+from pathlib import Path
+
+from server.index_lock import LOCK_NAME, exclusive_index
+
+ROOT = str(Path(__file__).resolve().parents[1])
+
+_CHILD = r"""
+import sys, time
+from pathlib import Path
+from server.index_lock import exclusive_index
+folder, hold, marker = sys.argv[1], float(sys.argv[2]), sys.argv[3]
+with exclusive_index(folder):
+    time.sleep(hold)
+    Path(marker).write_text("done")
+"""
+
+
+def _run(folder, hold, marker):
+    env = os.environ.copy()
+    env["PYTHONPATH"] = ROOT + os.pathsep + env.get("PYTHONPATH", "")
+    return subprocess.Popen(
+        [sys.executable, "-c", _CHILD, folder, str(hold), marker],
+        env=env,
+        cwd=ROOT,
+    )
+
+
+class IndexLockTests(unittest.TestCase):
+    def test_creates_lockfile(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            with exclusive_index(tmp) as folder:
+                self.assertTrue((Path(folder) / LOCK_NAME).is_file())
+
+    def test_second_process_waits(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            first_mark = str(Path(tmp) / "first")
+            second_mark = str(Path(tmp) / "second")
+            first = _run(tmp, 0.5, first_mark)
+            time.sleep(0.15)
+            t0 = time.time()
+            second = _run(tmp, 0.0, second_mark)
+            self.assertEqual(second.wait(timeout=5), 0)
+            waited = time.time() - t0
+            self.assertEqual(first.wait(timeout=5), 0)
+            self.assertEqual(Path(second_mark).read_text(), "done")
+            self.assertGreaterEqual(waited, 0.25)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/imagespace/tests/test_iqr_head.py
+++ b/imagespace/tests/test_iqr_head.py
@@ -1,0 +1,22 @@
+import unittest
+
+try:
+    from server.iqr import build_head
+    build_head(8)
+    KERAS = True
+except Exception:
+    KERAS = False
+
+
+@unittest.skipUnless(KERAS, "Keras not installed; phase 1 does not require it")
+class IqrHeadTests(unittest.TestCase):
+    def test_output_shape(self):
+        import numpy as np
+
+        model = build_head(8)
+        out = model.predict(np.zeros((2, 8), dtype="float32"), verbose=0)
+        self.assertEqual(out.shape, (2, 1))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/imagespace/tests/test_iqr_refine.py
+++ b/imagespace/tests/test_iqr_refine.py
@@ -1,0 +1,65 @@
+import tempfile
+import unittest
+
+import numpy as np
+
+from server.iqr import keras_available, refine
+from server.similar import ClipIndex, save_index
+
+
+@unittest.skipUnless(keras_available(), "Keras not installed")
+class IqrRefineTests(unittest.TestCase):
+    def test_positives_rank_above_negatives(self):
+        ids = ["pos.jpg", "neg.jpg", "other.jpg"]
+        vectors = np.array(
+            [
+                [1.0, 0.0, 0.0, 0.0],
+                [0.0, 1.0, 0.0, 0.0],
+                [0.8, 0.2, 0.0, 0.0],
+            ],
+            dtype="float32",
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            save_index(ids, vectors, {"model": "test", "dim": 4}, tmp)
+            index = ClipIndex(tmp)
+            hits, stats = refine(index, ["pos.jpg"], ["neg.jpg"], n=3)
+            ranked = [h["id"] for h in hits]
+            self.assertEqual(stats["positive"], 1)
+            self.assertEqual(stats["negative"], 1)
+            self.assertLess(ranked.index("pos.jpg"), ranked.index("neg.jpg"))
+            self.assertLess(ranked.index("other.jpg"), ranked.index("neg.jpg"))
+
+    def test_needs_both_classes(self):
+        ids = ["a.jpg", "b.jpg"]
+        vectors = np.array([[1.0, 0.0], [0.0, 1.0]], dtype="float32")
+        with tempfile.TemporaryDirectory() as tmp:
+            save_index(ids, vectors, {"model": "test", "dim": 2}, tmp)
+            index = ClipIndex(tmp)
+            with self.assertRaises(ValueError):
+                refine(index, ["a.jpg"], [], n=2)
+            with self.assertRaises(ValueError):
+                refine(index, ["missing.jpg"], ["also-missing.jpg"], n=2)
+
+    def test_scores_are_descending_probabilities(self):
+        ids = ["pos.jpg", "neg.jpg", "other.jpg"]
+        vectors = np.array(
+            [
+                [1.0, 0.0, 0.0, 0.0],
+                [0.0, 1.0, 0.0, 0.0],
+                [0.8, 0.2, 0.0, 0.0],
+            ],
+            dtype="float32",
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            save_index(ids, vectors, {"model": "test", "dim": 4}, tmp)
+            index = ClipIndex(tmp)
+            hits, _stats = refine(index, ["pos.jpg"], ["neg.jpg"], n=3)
+            scores = [h["iqr_score"] for h in hits]
+            self.assertEqual(scores, sorted(scores, reverse=True))
+            for score in scores:
+                self.assertGreaterEqual(score, 0.0)
+                self.assertLessEqual(score, 1.0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/imagespace/tests/test_progress.py
+++ b/imagespace/tests/test_progress.py
@@ -1,0 +1,27 @@
+import os
+import tempfile
+import unittest
+from pathlib import Path
+
+from server.progress import write_progress
+
+
+class ProgressTests(unittest.TestCase):
+    def test_writes_dot_progress(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = write_progress(50, 612, "encoded", tmp)
+            text = Path(path).read_text(encoding="utf-8")
+            self.assertEqual(text, "done=50\ntotal=612\nmsg=encoded\n")
+
+    def test_pge_progress_dir_env(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            os.environ["PGE_PROGRESS_DIR"] = tmp
+            try:
+                path = write_progress(1, 2, "split")
+                self.assertEqual(Path(path).parent, Path(tmp))
+            finally:
+                del os.environ["PGE_PROGRESS_DIR"]
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/imagespace/tests/test_query.py
+++ b/imagespace/tests/test_query.py
@@ -1,0 +1,51 @@
+import unittest
+
+from server.solr import field_query, filter_queries, is_field_query, parse_field_clause, search_params, user_query
+
+
+class QueryTests(unittest.TestCase):
+    def test_star_is_match_all(self):
+        self.assertEqual(user_query("*"), "*:*")
+        self.assertEqual(user_query("  "), "*:*")
+        self.assertEqual(user_query(None), "*:*")
+
+    def test_text_passes_through(self):
+        self.assertEqual(user_query("Elisa"), "Elisa")
+
+    def test_field_query_quotes_and_escapes(self):
+        self.assertEqual(field_query("tiff_Make", "Canon"), 'tiff_Make:"Canon"')
+        self.assertEqual(field_query("By_line", 'Elisa "X"'), 'By_line:"Elisa \\"X\\""')
+        self.assertTrue(is_field_query('tiff_Make:"Canon"'))
+        self.assertFalse(is_field_query("Elisa"))
+        with self.assertRaises(ValueError):
+            field_query("clip_score", "0.9")
+        with self.assertRaises(ValueError):
+            field_query("tiff_Make", "")
+
+    def test_parse_field_clause_roundtrip(self):
+        self.assertEqual(parse_field_clause('tiff_Make:"Canon"'), ("tiff_Make", "Canon"))
+        self.assertEqual(
+            parse_field_clause(field_query("By_line", 'Elisa "X"')),
+            ("By_line", 'Elisa "X"'),
+        )
+
+    def test_filter_queries_and_search_params(self):
+        clauses = filter_queries(
+            ['Exif_IFD0_Artist:"Matteo Chinellato"', 'tiff_Make:"Canon"']
+        )
+        self.assertEqual(
+            clauses,
+            ['Exif_IFD0_Artist:"Matteo Chinellato"', 'tiff_Make:"Canon"'],
+        )
+        params = search_params("*", 0, 24, clauses)
+        self.assertEqual(params["q"], "*:*")
+        self.assertEqual(params["fq"], clauses)
+        self.assertEqual(params["sort"], "id asc")
+        mixed = search_params("Elisa", 0, 24, ['tiff_Make:"Canon"'])
+        self.assertEqual(mixed["q"], "Elisa")
+        self.assertEqual(mixed["defType"], "edismax")
+        self.assertEqual(mixed["fq"], ['tiff_Make:"Canon"'])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/imagespace/tests/test_similar.py
+++ b/imagespace/tests/test_similar.py
@@ -1,0 +1,40 @@
+import tempfile
+import unittest
+from pathlib import Path
+
+import numpy as np
+
+from server.similar import ClipIndex, save_index
+
+
+class SimilarTests(unittest.TestCase):
+    def test_nearest_is_the_close_vector(self):
+        ids = ["a.jpg", "b.jpg", "c.jpg"]
+        vectors = np.array(
+            [
+                [1.0, 0.0, 0.0],
+                [0.95, 0.05, 0.0],
+                [0.0, 1.0, 0.0],
+            ],
+            dtype="float32",
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            save_index(ids, vectors, {"model": "test", "dim": 3}, tmp)
+            index = ClipIndex(tmp)
+            self.assertTrue(index.available())
+            hits = index.similar("a.jpg", n=2)
+            self.assertEqual(hits[0]["id"], "b.jpg")
+            self.assertGreater(hits[0]["clip_score"], hits[1]["clip_score"])
+            self.assertNotIn("a.jpg", [h["id"] for h in hits])
+            self.assertEqual(index.meta.get("backend"), "faiss")
+            self.assertTrue((Path(tmp) / "index.faiss").is_file())
+
+    def test_missing_index(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            index = ClipIndex(Path(tmp) / "nope")
+            self.assertFalse(index.available())
+            self.assertIsNone(index.similar("a.jpg"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/imagespace/tests/test_thumbs.py
+++ b/imagespace/tests/test_thumbs.py
@@ -1,0 +1,25 @@
+import tempfile
+import unittest
+from pathlib import Path
+
+from PIL import Image
+
+from server.images import make_thumb
+
+
+class ThumbTests(unittest.TestCase):
+    def test_thumb_is_smaller_jpeg(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            src = Path(tmp) / "big.jpg"
+            dest = Path(tmp) / "thumb.jpg"
+            Image.new("RGB", (2000, 1000), color=(40, 80, 120)).save(src, quality=95)
+            make_thumb(src, dest, 360)
+            self.assertTrue(dest.is_file())
+            with Image.open(dest) as out:
+                self.assertEqual(out.size[0], 360)
+                self.assertLess(out.size[1], 360)
+            self.assertLess(dest.stat().st_size, src.stat().st_size)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/imagespace/web/index.html
+++ b/imagespace/web/index.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1"/>
+    <title>ImageSpace</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com"/>
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Source+Sans+3:wght@400;600;700&display=swap"/>
+  </head>
+  <body>
+    <div id="app"></div>
+    <script type="module" src="/src/main.js"></script>
+  </body>
+</html>

--- a/imagespace/web/package-lock.json
+++ b/imagespace/web/package-lock.json
@@ -1,0 +1,1223 @@
+{
+  "name": "imagespace",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "imagespace",
+      "version": "0.1.0",
+      "dependencies": {
+        "vue": "^3.5.13"
+      },
+      "devDependencies": {
+        "@vitejs/plugin-vue": "^5.2.1",
+        "vite": "^5.4.14"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.8.tgz",
+      "integrity": "sha512-E8lTAYNB1KW+FH+VGJuZM1ioAx2E6oVlvQFRrf5P8ZZmsiJXYAD9vTFV7yyEURNzgh1dFqMZuO6tUwcARbqFCA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.8"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.8.tgz",
+      "integrity": "sha512-Vj1jF3cPfxg7OAfoI7QnVKLoILlm2JF9pnVHrX8qx7AHMiYWT+NDAA7jChlNgRS4WTLc/fD1lXLmPixluj+3Gg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.6.0.tgz",
+      "integrity": "sha512-T7jf+5zgsZHwNJ4lvQ7/aezbyk0nNX+zJVWpmHA7VYsEx7a7qr5Rg5IbtJFqkgze5Y2sruq1RUY8Q837Od7iFw==",
+      "license": "MIT"
+    },
+    "node_modules/@napi-rs/lzma-linux-x64-gnu": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@napi-rs/lzma-linux-x64-gnu/-/lzma-linux-x64-gnu-1.5.1.tgz",
+      "integrity": "sha512-oTXEIha4SsuXdTA4Iyskj0kpdx2yVXdhd75c2v3xGrHFfVMsbhTPZU/nMPL4sWKo4pBHm3aucLaqGlF696dTyQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^22.20 || ^24.12 || >=25"
+      }
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.63.1.tgz",
+      "integrity": "sha512-UZ8sUxPTiHWYX9QNdJedb1kDZSpS1t/VPWBWGSgqHNi9w3Cu6IXvu2mzbhiTiPvtrqgTQJ+zqiAq2iPIPilpaQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.63.1.tgz",
+      "integrity": "sha512-cQ4nFQABN5cDvDpbvJ7bMStCpnaVxynZrRMfUJYgxcIk9Sh54FIO1vtfkg0B69REjER77ioZ/ov+eAApx/KmLQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.63.1.tgz",
+      "integrity": "sha512-FQNqd1lRy/0QhDk3xeRIkSBiCpXCiDnZO3YLVdcDKN1UBiKToNftCzcXYNLshmPDUMlu2TdeS8tGcsU6f3YF1Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.63.1.tgz",
+      "integrity": "sha512-pvD16V939D3CloK0+qikpGaxiPrDUXTe7Y5cWOMkMSy7m1cawa8EGy/kXYi/G/cKAC4HDAbSnzCIk1WmsoOKXg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.63.1.tgz",
+      "integrity": "sha512-pcFGeL2345VwdTnJhA6zLbew+YgWB0qBG2+dMtXjCicf6+rm6kO6cOoh5VnTe0ZMrMRgRyuHmCJxZWrIdzYuOw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.63.1.tgz",
+      "integrity": "sha512-mRJlqSRulVzcKq/LKA6ICSIc3K/l4fzlVn/gePn2nXIHy8seRi5z/eeRE0d/XMBxcMldiXtQTSpRj0tkkC3g8Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.63.1.tgz",
+      "integrity": "sha512-YDUNvVM85TI3g/1OpnqKP1h4NeW/j64DfWMf+G3M809xNk1bJSnpFp4sh83NpmVE5DXnkh8ULor4LTVZKoYLHw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.63.1.tgz",
+      "integrity": "sha512-7Mcn71p9ZuQFAj+h+dhQXy/yeLePRS2yKRnmW1DijA9thKO5qap0GNOIQK4yQ6iP3SU0Mrb/yWo8h8vgRba8lw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.63.1.tgz",
+      "integrity": "sha512-4YiLQTX6U4CSl0L9cluep9A9W6UmTfqBDc2/CH6wlu54pl4E7Jn3cOD8oxzvBDEGk/JMKgJ47C8g+radF7mwvg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.63.1.tgz",
+      "integrity": "sha512-2ra8F7w8OquwZN9z2/fKFnli69wa8PLwaVzRMIPGb13ByMJwC28Fbp8YcVGoUhlYMTt7j5j9bNgpysrN2UM+vw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.63.1.tgz",
+      "integrity": "sha512-Sy20ncyhjmBP0Ml+UvQbimjlk6VFgjW5uNP+qqwHB00mTE8Bl2C1TuHTlRwK2YoXeZbee5lP2XevBWVkAQAtSQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.63.1.tgz",
+      "integrity": "sha512-noITLp8oNjYliPnGWmLyelIHwULGqbHloQHGw1rtxbWhTuWooRpnZarZQJ1y9EUC4szuCusCc+HEpUtxpIwYvA==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.63.1.tgz",
+      "integrity": "sha512-hlxxXd+F1mWiAcaFR7Sv9ZQT6m6UfI8+Vy/kFJzztq2pDMU/0wZ9sish0iszNZvsQDo8Gc0i5yuFEOz5dDf6fA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.63.1.tgz",
+      "integrity": "sha512-EF7OpqQTQ/BvGqLzUi4rEHuagCV9MugAUXSHemwPW5vxZ75RR+jxO/2j95Ph2dalMpFHSVECjRoioHZgA9zOYA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.63.1.tgz",
+      "integrity": "sha512-wQO3JesW9PRkwlabQ27y7sPfVOOTLRG73I4F2UYHG5PXun3J9U3y+b7ezVKSYbsvSKGQ1k1cq8Qlun4C9kLt3w==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.63.1.tgz",
+      "integrity": "sha512-ouAGwhO6wHRXdnOVCOsB0tRFkA7nhNB2Nwax6oECXN0YiN8EYUTBAOudADOB1PI+yDL61TeNx/u7MVCzksNbkQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.63.1.tgz",
+      "integrity": "sha512-q2R38Sn+1J8RxhfJ+T54wSWmyKXWec+9jgDfqO2AtArEqHO5R2aeayp5H5OYLr5UYDVGsVaZPEFUooMhYCdz5A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.63.1.tgz",
+      "integrity": "sha512-gfI5T24WLLuFfSKw7Go/zDXjAAV0fny0swTaDv+WjK7vqcw4cRhFfdsyKL1n+ukI+ooBxn3bVQnyrn06WpI50w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.63.1.tgz",
+      "integrity": "sha512-4h6XqthmB4Hspji84wvgk+ElodTsGj+dbZqHJHHtKxj4mYq0ANSEEPX9ys3moJueqsRjwpaJYH7874Itwnj2ow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.63.1.tgz",
+      "integrity": "sha512-dlfCOa87o1VAYegLQ9EKilx2JCeRofiyPGhTCmqnuXZ6bMPiycO1rq1+sKoulAp7pGLIsTIw+1x5R+zgh5LhhA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.63.1.tgz",
+      "integrity": "sha512-cjkLbOlfcm3QGhMM1J5zaZjsw1GggbN6rw9UTSSRrPrR1KkcXnN7Uq9rPw34xImQ9VOY9GN+6u2Zj80B9ptkcw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.63.1.tgz",
+      "integrity": "sha512-Li1KdUnWGE4N3e1F/B4RTB1ms+nG4WBgjByO46pkeBVX/2UBsY53xf5vK9WygVmnH3RwncIST7lkSdLSY6P9lg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.63.1.tgz",
+      "integrity": "sha512-t4ZYOSoLTgwhuFMrmTMLx/+i1DQVK7HYqMc6kY46EApwi8X0nIVphzdNoThU3xt6n+N5urG1/gxBdCaKDLavfg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.63.1.tgz",
+      "integrity": "sha512-RgroPfMmKlD1RzSDxvwgcPiy2HNQKoYV7OmwIXDsk73uKW5t6B/V8KIy27SMv/FNXFo/oSBtWc9J0X7t91ezZg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.63.1.tgz",
+      "integrity": "sha512-at8QVep6S3h5Y6gSbdGU06bRY5WJkf6WUduM9YtvYMbYhB1MOFfUgc6kehitQXzOtMSaT70q7f9ydPhpqu821w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@vitejs/plugin-vue": {
+      "version": "5.2.4",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-vue/-/plugin-vue-5.2.4.tgz",
+      "integrity": "sha512-7Yx/SXSOcQq5HiiV3orevHUFn+pmMB4cgbEkDYgnkUWb0WfeQ/wa2yFv6D5ICiCQOVpjA7vYDXrC7AGO8yjDHA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "peerDependencies": {
+        "vite": "^5.0.0 || ^6.0.0",
+        "vue": "^3.2.25"
+      }
+    },
+    "node_modules/@vue/compiler-core": {
+      "version": "3.5.42",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.42.tgz",
+      "integrity": "sha512-2Ye1ilMtKXxl8qZUrQ5j0CdgenFp/HFQmta6rfRyfEsTG69L6Wk+tWuNoHYHMx9E8tF2Slvdg1FuwDvAXdy1LQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.8",
+        "@vue/shared": "3.5.42",
+        "entities": "^7.0.1",
+        "estree-walker": "^2.0.2",
+        "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/@vue/compiler-dom": {
+      "version": "3.5.42",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.42.tgz",
+      "integrity": "sha512-qbhQZEFmycr+ni/qyuccS4sucNN7VAbDfbkvNxWOX2VfgFm90MNs3/UhRNKoPMEIVn0F8gdlYjLPvqxHwHeQOA==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/compiler-core": "3.5.42",
+        "@vue/shared": "3.5.42"
+      }
+    },
+    "node_modules/@vue/compiler-sfc": {
+      "version": "3.5.42",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.5.42.tgz",
+      "integrity": "sha512-fkCAFB4okcAANGMThboWnScp/gzWjU0ZSkVnjTIiplmMDq2uq0tIB3j+xVu4rhv5rvOgBySCysudmbMd6xRRqw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.8",
+        "@vue/compiler-core": "3.5.42",
+        "@vue/compiler-dom": "3.5.42",
+        "@vue/compiler-ssr": "3.5.42",
+        "@vue/shared": "3.5.42",
+        "estree-walker": "^2.0.2",
+        "magic-string": "^0.30.21",
+        "postcss": "^8.5.19",
+        "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/@vue/compiler-ssr": {
+      "version": "3.5.42",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.5.42.tgz",
+      "integrity": "sha512-xmLk3wLkbizPAiLyomjgFFosf2ys9b5Ghb+oh/k2tnvipNz8OFrQOiTcWCzyK7MpBp9KkyGtfvgfLUivbmuGYA==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/compiler-dom": "3.5.42",
+        "@vue/shared": "3.5.42"
+      }
+    },
+    "node_modules/@vue/reactivity": {
+      "version": "3.5.42",
+      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.5.42.tgz",
+      "integrity": "sha512-TzNNfKpb7hDxbQltwAut8VDQA5YP+BuRlxntHUuRjyKwlMvmAPbs3unhCvieijifY6vFfVBwsS7wG/C7uq+bEQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/shared": "3.5.42"
+      }
+    },
+    "node_modules/@vue/runtime-core": {
+      "version": "3.5.42",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.5.42.tgz",
+      "integrity": "sha512-9uACtuHs7vJGkm5Bp3xu4xRDLFTIYy5DgxpToVjqGIAhAEKwQfsaLvKINhM6nFVp6bZPRFGdDqd1g52MqKsotA==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/reactivity": "3.5.42",
+        "@vue/shared": "3.5.42"
+      }
+    },
+    "node_modules/@vue/runtime-dom": {
+      "version": "3.5.42",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.5.42.tgz",
+      "integrity": "sha512-rsCmhiWLaRxGltLwhlCWyYkFn7WAbKRh0q17eZ1A6Dq6eqc2ACQ61IIryxz0LrsvCzHSilLA9JHovVwM8CNE2g==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/reactivity": "3.5.42",
+        "@vue/runtime-core": "3.5.42",
+        "@vue/shared": "3.5.42",
+        "csstype": "^3.2.3"
+      }
+    },
+    "node_modules/@vue/server-renderer": {
+      "version": "3.5.42",
+      "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.5.42.tgz",
+      "integrity": "sha512-2++5dUyYS4gvo7xQXSECUDhB7TS0aOl5SeVfC5qSq1Jgfhjvegw1zqhwTIR3imZ+QYPJQw9gfcFvXGAjGZ7ajQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/compiler-ssr": "3.5.42",
+        "@vue/runtime-dom": "3.5.42",
+        "@vue/shared": "3.5.42"
+      }
+    },
+    "node_modules/@vue/shared": {
+      "version": "3.5.42",
+      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.42.tgz",
+      "integrity": "sha512-2rPxex1jQf4jvl9MOHl6YaXCPcrNqz/FstMOEh3QWY+/OME9nQTvl9WYeCwhW7AFjaR0SnngZGlp/wkR6rkI6g==",
+      "license": "MIT"
+    },
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "license": "MIT"
+    },
+    "node_modules/entities": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.21.5",
+        "@esbuild/android-arm": "0.21.5",
+        "@esbuild/android-arm64": "0.21.5",
+        "@esbuild/android-x64": "0.21.5",
+        "@esbuild/darwin-arm64": "0.21.5",
+        "@esbuild/darwin-x64": "0.21.5",
+        "@esbuild/freebsd-arm64": "0.21.5",
+        "@esbuild/freebsd-x64": "0.21.5",
+        "@esbuild/linux-arm": "0.21.5",
+        "@esbuild/linux-arm64": "0.21.5",
+        "@esbuild/linux-ia32": "0.21.5",
+        "@esbuild/linux-loong64": "0.21.5",
+        "@esbuild/linux-mips64el": "0.21.5",
+        "@esbuild/linux-ppc64": "0.21.5",
+        "@esbuild/linux-riscv64": "0.21.5",
+        "@esbuild/linux-s390x": "0.21.5",
+        "@esbuild/linux-x64": "0.21.5",
+        "@esbuild/netbsd-x64": "0.21.5",
+        "@esbuild/openbsd-x64": "0.21.5",
+        "@esbuild/sunos-x64": "0.21.5",
+        "@esbuild/win32-arm64": "0.21.5",
+        "@esbuild/win32-ia32": "0.21.5",
+        "@esbuild/win32-x64": "0.21.5"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+      "license": "MIT"
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "license": "ISC"
+    },
+    "node_modules/postcss": {
+      "version": "8.5.26",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
+      "integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.17",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.63.1.tgz",
+      "integrity": "sha512-3Df9jsstwhccuEfmAMi9l8XUh/GOkVObmFTU7CCVBysEbcOZLl84jCtaAZMcPiMz2EGKsATzQcU+Xr3n/wU6cg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.9"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@napi-rs/lzma-linux-x64-gnu": "1.5.1",
+        "@rollup/rollup-android-arm-eabi": "4.63.1",
+        "@rollup/rollup-android-arm64": "4.63.1",
+        "@rollup/rollup-darwin-arm64": "4.63.1",
+        "@rollup/rollup-darwin-x64": "4.63.1",
+        "@rollup/rollup-freebsd-arm64": "4.63.1",
+        "@rollup/rollup-freebsd-x64": "4.63.1",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.63.1",
+        "@rollup/rollup-linux-arm-musleabihf": "4.63.1",
+        "@rollup/rollup-linux-arm64-gnu": "4.63.1",
+        "@rollup/rollup-linux-arm64-musl": "4.63.1",
+        "@rollup/rollup-linux-loong64-gnu": "4.63.1",
+        "@rollup/rollup-linux-loong64-musl": "4.63.1",
+        "@rollup/rollup-linux-ppc64-gnu": "4.63.1",
+        "@rollup/rollup-linux-ppc64-musl": "4.63.1",
+        "@rollup/rollup-linux-riscv64-gnu": "4.63.1",
+        "@rollup/rollup-linux-riscv64-musl": "4.63.1",
+        "@rollup/rollup-linux-s390x-gnu": "4.63.1",
+        "@rollup/rollup-linux-x64-gnu": "4.63.1",
+        "@rollup/rollup-linux-x64-musl": "4.63.1",
+        "@rollup/rollup-openbsd-x64": "4.63.1",
+        "@rollup/rollup-openharmony-arm64": "4.63.1",
+        "@rollup/rollup-win32-arm64-msvc": "4.63.1",
+        "@rollup/rollup-win32-ia32-msvc": "4.63.1",
+        "@rollup/rollup-win32-x64-gnu": "4.63.1",
+        "@rollup/rollup-win32-x64-msvc": "4.63.1",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/vite": {
+      "version": "5.4.21",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
+      "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.21.3",
+        "postcss": "^8.4.43",
+        "rollup": "^4.20.0"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vue": {
+      "version": "3.5.42",
+      "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.42.tgz",
+      "integrity": "sha512-4RyHQTbQvOPs3MfvUO1Sg0YRrKNnA0mAVtvpd12Tg1fKDN7OHBUl1IqSn8zGJjK9nI3NkNp8cgTpVrSZC5TTcA==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/compiler-dom": "3.5.42",
+        "@vue/compiler-sfc": "3.5.42",
+        "@vue/runtime-dom": "3.5.42",
+        "@vue/server-renderer": "3.5.42",
+        "@vue/shared": "3.5.42"
+      },
+      "peerDependencies": {
+        "typescript": "*"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    }
+  }
+}

--- a/imagespace/web/package.json
+++ b/imagespace/web/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "imagespace",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "test": "node --test src/*.test.js"
+  },
+  "dependencies": {
+    "vue": "^3.5.13"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-vue": "^5.2.1",
+    "vite": "^5.4.14"
+  }
+}

--- a/imagespace/web/src/App.vue
+++ b/imagespace/web/src/App.vue
@@ -1,0 +1,485 @@
+<template>
+  <div class="shell">
+    <aside class="tray">
+      <h2>Saved</h2>
+      <p v-if="!tray.length" class="empty">Save an image from the grid to pin it here.</p>
+      <button v-for="row in tray" :key="row.id" class="tray-item" :class="{ active: open && open.id === row.id }" @click="openDoc(row.id)">
+        <img :src="fileSrc(row.id, 180)" :alt="basename(row.id)" loading="lazy" decoding="async"/>
+      </button>
+    </aside>
+    <div class="main">
+      <header class="mast">
+        <div>
+          <h1>ImageSpace</h1>
+          <p>ImageCat Solr {{ health && health.numFound != null ? health.numFound + ' docs' : '' }}</p>
+        </div>
+        <div class="search-stack">
+          <form class="search" @submit.prevent="runSearch(0)">
+            <input v-model="q" type="search" placeholder="OCR / metadata, or * to browse" @keydown.enter.prevent="runSearch(0)" @search="onSearchBox"/>
+            <button type="submit">Search</button>
+          </form>
+          <div v-if="filters.length || addingFilter" class="filters">
+            <span v-for="(chip, i) in filters" :key="chip.field + ':' + chip.value" class="chip">
+              <span class="chip-text" :title="filterLabel(chip)">{{ filterLabel(chip) }}</span>
+              <button class="chip-x" type="button" :title="'Remove ' + chip.field" @click="dropFilter(i)">×</button>
+            </span>
+            <button v-if="!addingFilter" class="chip-add" type="button" title="Add filter" @click="startAddFilter">+</button>
+            <form v-else class="chip-new" @submit.prevent="submitNewFilter">
+              <input ref="newFieldEl" v-model="newField" list="field-hints" placeholder="field" @keydown.escape.prevent="cancelAddFilter"/>
+              <input v-model="newValue" placeholder="value" @keydown.escape.prevent="cancelAddFilter"/>
+              <button type="submit" class="chip-add" title="Add">+</button>
+              <button type="button" class="chip-x" title="Cancel" @click="cancelAddFilter">×</button>
+            </form>
+            <datalist id="field-hints">
+              <option v-for="name in fieldHints" :key="name" :value="name"/>
+            </datalist>
+          </div>
+        </div>
+        <div v-if="similarTo" class="query-wrap">
+          <button class="query-image" type="button" :title="similarTo" @click="openDoc(similarTo)">
+            <img :src="fileSrc(similarTo, 180)" :alt="basename(similarTo)" decoding="async"/>
+            <span>
+              <em>{{ similarLabel }}</em>
+              {{ basename(similarTo) }}
+            </span>
+          </button>
+          <button class="query-clear" type="button" title="Clear similar" @click="clearSimilar">×</button>
+        </div>
+      </header>
+      <p v-if="error" class="banner">{{ error }}</p>
+      <p class="status">{{ statusLine }}</p>
+      <div class="iqr-bar">
+        <span v-if="canIqr">IQR {{ iqrPos.length }} relevant / {{ iqrNeg.length }} not</span>
+        <span v-else title="Python 3.9+ with Keras and TensorFlow">IQR off (needs Keras)</span>
+        <button :disabled="!canIqr || !iqrPos.length || !iqrNeg.length || loading" title="Fit the Keras head on CLIP vectors and rerank" @click="runIqr">Refine</button>
+        <button class="ghost" :disabled="!iqrPos.length && !iqrNeg.length && !iqrActive" @click="clearIqr">Clear labels</button>
+      </div>
+      <div class="grid">
+        <article v-for="doc in docs" :key="doc.id" class="tile" :class="{ pos: isPos(doc.id), neg: isNeg(doc.id) }">
+          <img :src="fileSrc(doc.id, 360)" :alt="basename(doc.id)" loading="lazy" decoding="async" @click="openDoc(doc.id)"/>
+          <p class="ocr">{{ scoreLine(doc) }}</p>
+          <div class="actions">
+            <button class="ghost" @click="toggle(doc)">{{ saved(doc.id) ? 'Remove' : 'Save' }}</button>
+            <button class="ghost" @click="openDoc(doc.id)">Details</button>
+            <button :disabled="!canSimilar" :title="canSimilar ? 'CLIP neighbors' : 'Build the CLIP index first'" @click="runSimilar(doc, 'clip')">Similar</button>
+            <button class="ghost" :disabled="!canFg(doc)" :title="fgTitle(doc)" @click="runSimilar(doc, 'fg')">FG</button>
+            <button class="ghost" :disabled="!canBg(doc)" :title="bgTitle(doc)" @click="runSimilar(doc, 'bg')">BG</button>
+            <button class="ghost" :class="{ on: isPos(doc.id) }" :disabled="!canIqr" title="Relevant" @click="markPos(doc.id)">+</button>
+            <button class="ghost" :class="{ on: isNeg(doc.id) }" :disabled="!canIqr" title="Not relevant" @click="markNeg(doc.id)">−</button>
+          </div>
+        </article>
+      </div>
+      <p v-if="loading && !docs.length" class="status">Loading…</p>
+      <p v-else-if="!docs.length && !loading" class="status">No images for this query.</p>
+      <button v-if="docs.length < numFound" class="more ghost" type="button" :disabled="loading" @click="loadMore">Load more</button>
+    </div>
+    <div v-if="open" class="detail" @click.self="open = null">
+      <div class="detail-card">
+        <div class="detail-top">
+          <img :src="fileSrc(open.id, 1280)" :alt="basename(open.id)" decoding="async"/>
+          <div>
+            <h2>{{ basename(open.id) }}</h2>
+            <p class="status">{{ open.id }}</p>
+            <div class="row">
+              <button class="ghost" @click="toggle(open)">{{ saved(open.id) ? 'Remove from tray' : 'Save to tray' }}</button>
+              <button :disabled="!canSimilar" :title="canSimilar ? 'CLIP neighbors' : 'Build the CLIP index first'" @click="runSimilar(open, 'clip')">Find similar</button>
+              <button class="ghost" :disabled="!canFg(open)" :title="fgTitle(open)" @click="runSimilar(open, 'fg')">Similar FG</button>
+              <button class="ghost" :disabled="!canBg(open)" :title="bgTitle(open)" @click="runSimilar(open, 'bg')">Similar BG</button>
+              <button class="ghost" :class="{ on: isPos(open.id) }" :disabled="!canIqr" @click="markPos(open.id)">Relevant</button>
+              <button class="ghost" :class="{ on: isNeg(open.id) }" :disabled="!canIqr" @click="markNeg(open.id)">Not relevant</button>
+              <button class="ghost" @click="open = null">Close</button>
+            </div>
+          </div>
+        </div>
+        <dl>
+          <template v-for="[key, val] in fieldEntries(open)" :key="key">
+            <dt>{{ key }}</dt>
+            <dd>
+              <template v-if="canSearchField(key) && valueList(val).length">
+                <button
+                  v-for="(item, i) in valueList(val)"
+                  :key="i"
+                  class="field-hit"
+                  :class="{ on: isActiveFilter(filters, key, item) }"
+                  type="button"
+                  :title="'Find other images with this ' + key"
+                  @click="searchField(key, item)"
+                >{{ formatOne(item) }}</button>
+              </template>
+              <span v-else>{{ formatVal(val) }}</span>
+            </dd>
+          </template>
+        </dl>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script>
+import { computed, nextTick, onMounted, ref } from 'vue'
+import { canSearchField, fieldEntries, fileSrc, getDoc, getHealth, refineIqr, scalar, search, similar, valueList } from './api.js'
+import { addFilter, filterLabel, isActiveFilter, looksLikeFieldQuery, removeFilter } from './filters.js'
+import { inTray, loadTray, saveTray, toggleTray } from './tray.js'
+
+export default {
+  name: 'App',
+  setup() {
+    const q = ref('*')
+    const filters = ref([])
+    const addingFilter = ref(false)
+    const newField = ref('')
+    const newValue = ref('')
+    const newFieldEl = ref(null)
+    const docs = ref([])
+    const numFound = ref(0)
+    const loading = ref(false)
+    const error = ref('')
+    const open = ref(null)
+    const tray = ref(loadTray())
+    const health = ref(null)
+    const similarTo = ref('')
+    const similarSpace = ref('clip')
+    const iqrPos = ref([])
+    const iqrNeg = ref([])
+    const iqrActive = ref(false)
+    const refining = ref(false)
+
+    const canSimilar = computed(() => Boolean(health.value && health.value.capabilities && health.value.capabilities.similar))
+    const canIqr = computed(() => Boolean(health.value && health.value.capabilities && health.value.capabilities.iqr))
+    const canFgbg = computed(() => Boolean(health.value && health.value.capabilities && health.value.capabilities.fgbg))
+
+    function canFg(doc) {
+      if (!canFgbg.value || !doc) {
+        return false
+      }
+      return doc.fg_indexed !== false
+    }
+
+    function canBg(doc) {
+      if (!canFgbg.value || !doc) {
+        return false
+      }
+      return doc.bg_indexed !== false
+    }
+
+    function fgTitle(doc) {
+      if (!canFgbg.value) {
+        return 'Build the fg/bg index first'
+      }
+      if (doc && doc.fg_indexed === false) {
+        return 'This image is not in the fg index yet'
+      }
+      return 'Foreground CLIP neighbors'
+    }
+
+    function bgTitle(doc) {
+      if (!canFgbg.value) {
+        return 'Build the fg/bg index first'
+      }
+      if (doc && doc.bg_indexed === false) {
+        return 'This image is not in the bg index yet'
+      }
+      return 'Background CLIP neighbors'
+    }
+    const similarLabel = computed(() => {
+      if (similarSpace.value === 'fg') {
+        return 'Similar FG'
+      }
+      if (similarSpace.value === 'bg') {
+        return 'Similar BG'
+      }
+      return 'Similar to'
+    })
+
+    const statusLine = computed(() => {
+      if (loading.value && refining.value) {
+        return 'Refining…'
+      }
+      if (loading.value && !docs.value.length) {
+        return similarTo.value ? 'Finding similar…' : 'Searching…'
+      }
+      const count = numFound.value + ' image' + (numFound.value === 1 ? '' : 's')
+      if (iqrActive.value) {
+        return 'IQR ranked — ' + count
+      }
+      if (similarTo.value) {
+        const kind = similarSpace.value === 'fg' ? 'FG similar to ' : similarSpace.value === 'bg' ? 'BG similar to ' : 'Similar to '
+        return kind + basename(similarTo.value) + ' — ' + count
+      }
+      return count
+    })
+
+    function scoreLine(doc) {
+      const text = scalar(doc.ocr_text) || basename(doc.id)
+      if (doc.iqr_score != null && doc.iqr_score !== '') {
+        return Number(doc.iqr_score).toFixed(3) + ' · ' + text
+      }
+      if (doc.clip_score == null || doc.clip_score === '') {
+        return text
+      }
+      return Number(doc.clip_score).toFixed(3) + ' · ' + text
+    }
+
+    function isPos(id) {
+      return iqrPos.value.indexOf(id) !== -1
+    }
+
+    function isNeg(id) {
+      return iqrNeg.value.indexOf(id) !== -1
+    }
+
+    function markPos(id) {
+      iqrNeg.value = iqrNeg.value.filter((item) => item !== id)
+      if (isPos(id)) {
+        iqrPos.value = iqrPos.value.filter((item) => item !== id)
+      } else {
+        iqrPos.value = iqrPos.value.concat([id])
+      }
+    }
+
+    function markNeg(id) {
+      iqrPos.value = iqrPos.value.filter((item) => item !== id)
+      if (isNeg(id)) {
+        iqrNeg.value = iqrNeg.value.filter((item) => item !== id)
+      } else {
+        iqrNeg.value = iqrNeg.value.concat([id])
+      }
+    }
+
+    function basename(id) {
+      const parts = String(id || '').split('/')
+      return parts[parts.length - 1] || id
+    }
+
+    function formatOne(val) {
+      return val == null ? '' : String(val)
+    }
+
+    function formatVal(val) {
+      if (Array.isArray(val)) {
+        return val.join(', ')
+      }
+      if (val && typeof val === 'object') {
+        return JSON.stringify(val)
+      }
+      return formatOne(val)
+    }
+
+    const fieldHints = computed(() => {
+      const names = {}
+      docs.value.forEach((doc) => {
+        Object.keys(doc || {}).forEach((key) => {
+          if (canSearchField(key)) {
+            names[key] = true
+          }
+        })
+      })
+      return Object.keys(names).sort()
+    })
+
+    function searchField(field, value) {
+      const next = addFilter(filters.value, field, value)
+      if (!next.length) {
+        return
+      }
+      filters.value = next
+      if (looksLikeFieldQuery(q.value)) {
+        q.value = '*'
+      }
+      open.value = null
+      runSearch(0)
+    }
+
+    function dropFilter(index) {
+      filters.value = removeFilter(filters.value, index)
+      runSearch(0)
+    }
+
+    async function startAddFilter() {
+      addingFilter.value = true
+      newField.value = ''
+      newValue.value = ''
+      await nextTick()
+      if (newFieldEl.value) {
+        newFieldEl.value.focus()
+      }
+    }
+
+    function cancelAddFilter() {
+      addingFilter.value = false
+      newField.value = ''
+      newValue.value = ''
+    }
+
+    function submitNewFilter() {
+      const next = addFilter(filters.value, newField.value.trim(), newValue.value.trim())
+      if (next.length === filters.value.length) {
+        cancelAddFilter()
+        return
+      }
+      filters.value = next
+      cancelAddFilter()
+      runSearch(0)
+    }
+
+    function saved(id) {
+      return inTray(tray.value, id)
+    }
+
+    function toggle(doc) {
+      tray.value = toggleTray(tray.value, doc)
+      saveTray(tray.value)
+    }
+
+    async function runSearch(start) {
+      loading.value = true
+      error.value = ''
+      similarTo.value = ''
+      similarSpace.value = 'clip'
+      iqrActive.value = false
+      if (!start) {
+        docs.value = []
+      }
+      try {
+        const body = await search(q.value, start || 0, 24, filters.value)
+        numFound.value = body.numFound || 0
+        docs.value = start ? docs.value.concat(body.docs || []) : (body.docs || [])
+      } catch (e) {
+        error.value = e.message || String(e)
+      } finally {
+        loading.value = false
+      }
+    }
+
+    function onSearchBox() {
+      if (q.value && q.value.trim() !== '') {
+        return
+      }
+      q.value = '*'
+      similarTo.value = ''
+      similarSpace.value = 'clip'
+      iqrActive.value = false
+      runSearch(0)
+    }
+
+    function clearSimilar() {
+      similarTo.value = ''
+      similarSpace.value = 'clip'
+      q.value = '*'
+      runSearch(0)
+    }
+
+    async function runIqr() {
+      if (!canIqr.value || !iqrPos.value.length || !iqrNeg.value.length) {
+        return
+      }
+      loading.value = true
+      refining.value = true
+      error.value = ''
+      open.value = null
+      try {
+        const body = await refineIqr(iqrPos.value, iqrNeg.value, 48)
+        similarTo.value = ''
+        iqrActive.value = true
+        numFound.value = body.numFound || 0
+        docs.value = body.docs || []
+      } catch (e) {
+        error.value = e.message || String(e)
+      } finally {
+        refining.value = false
+        loading.value = false
+      }
+    }
+
+    function clearIqr() {
+      iqrPos.value = []
+      iqrNeg.value = []
+      if (iqrActive.value) {
+        runSearch(0)
+      }
+    }
+
+    async function runSimilar(doc, space, n) {
+      const mode = space || 'clip'
+      if (!doc || !doc.id) {
+        return
+      }
+      if (mode === 'clip' && !canSimilar.value) {
+        return
+      }
+      if (mode === 'fg' && !canFg(doc)) {
+        return
+      }
+      if (mode === 'bg' && !canBg(doc)) {
+        return
+      }
+      loading.value = true
+      error.value = ''
+      open.value = null
+      iqrActive.value = false
+      try {
+        const body = await similar(doc.id, n || 24, mode)
+        similarTo.value = doc.id
+        similarSpace.value = mode
+        numFound.value = body.numFound || 0
+        docs.value = body.docs || []
+      } catch (e) {
+        error.value = e.message || String(e)
+      } finally {
+        loading.value = false
+      }
+    }
+
+    async function loadMore() {
+      if (loading.value || docs.value.length >= numFound.value) {
+        return
+      }
+      if (iqrActive.value) {
+        loading.value = true
+        refining.value = true
+        error.value = ''
+        try {
+          const body = await refineIqr(iqrPos.value, iqrNeg.value, docs.value.length + 24)
+          numFound.value = body.numFound || 0
+          docs.value = body.docs || []
+        } catch (e) {
+          error.value = e.message || String(e)
+        } finally {
+          refining.value = false
+          loading.value = false
+        }
+        return
+      }
+      if (similarTo.value) {
+        await runSimilar({ id: similarTo.value, fg_indexed: true, bg_indexed: true }, similarSpace.value, docs.value.length + 24)
+        return
+      }
+      await runSearch(docs.value.length)
+    }
+
+    async function openDoc(id) {
+      try {
+        const body = await getDoc(id)
+        open.value = (body && body.doc) || docs.value.find((d) => d.id === id) || { id }
+      } catch (e) {
+        error.value = e.message || String(e)
+      }
+    }
+
+    onMounted(async () => {
+      try {
+        health.value = await getHealth()
+      } catch (e) {
+        error.value = e.message || String(e)
+      }
+      await runSearch(0)
+    })
+
+    return {
+      q, filters, addingFilter, newField, newValue, newFieldEl, fieldHints, docs, numFound, loading, error, open, tray, health, similarTo, similarSpace, iqrPos, iqrNeg, iqrActive, refining,
+      statusLine, canSimilar, canIqr, canFgbg, canFg, canBg, fgTitle, bgTitle, similarLabel, isPos, isNeg, markPos, markNeg, runIqr, clearIqr,
+      basename, scoreLine, formatVal, formatOne, searchField, dropFilter, startAddFilter, cancelAddFilter, submitNewFilter, filterLabel, isActiveFilter, canSearchField, valueList, saved, toggle, runSearch, onSearchBox, loadMore, runSimilar, clearSimilar, openDoc, fileSrc, fieldEntries, scalar
+    }
+  }
+}
+</script>

--- a/imagespace/web/src/api.js
+++ b/imagespace/web/src/api.js
@@ -1,0 +1,117 @@
+export async function readJson(response) {
+  const text = await response.text()
+  let body = {}
+  if (text) {
+    try {
+      body = JSON.parse(text)
+    } catch (e) {
+      body = { error: text }
+    }
+  }
+  if (!response.ok) {
+    throw new Error(body.detail || body.error || text || response.statusText)
+  }
+  return body
+}
+
+export function search(q, start, rows, filters) {
+  const params = new URLSearchParams()
+  params.set('q', q || '*')
+  params.set('start', String(start || 0))
+  params.set('rows', String(rows || 24))
+  ;(filters || []).forEach((item) => {
+    const clause = typeof item === 'string' ? item : fieldSearchQuery(item.field, item.value)
+    if (clause) {
+      params.append('fq', clause)
+    }
+  })
+  return fetch(`/api/search?${params}`).then(readJson)
+}
+
+export function getDoc(id) {
+  const params = new URLSearchParams()
+  params.set('id', id)
+  return fetch(`/api/doc?${params}`).then(readJson)
+}
+
+export function getHealth() {
+  return fetch('/api/health').then(readJson)
+}
+
+export function similar(id, n, space) {
+  const params = new URLSearchParams()
+  params.set('id', id)
+  params.set('n', String(n || 24))
+  if (space && space !== 'clip') {
+    params.set('space', space)
+  }
+  return fetch(`/api/similar?${params}`).then(readJson)
+}
+
+export function refineIqr(positive, negative, n) {
+  return fetch('/api/iqr/refine', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      positive: positive || [],
+      negative: negative || [],
+      n: n || 24
+    })
+  }).then(readJson)
+}
+
+export function fileSrc(id, width) {
+  const params = new URLSearchParams()
+  params.set('id', id)
+  if (width) {
+    params.set('w', String(width))
+  }
+  return `/api/file?${params}`
+}
+
+export function scalar(value) {
+  if (Array.isArray(value) && value.length) {
+    return value[0]
+  }
+  return value
+}
+
+export function fieldEntries(doc) {
+  const skip = { highlight: true, _root_: true }
+  return Object.keys(doc || {})
+    .filter((key) => !skip[key])
+    .sort()
+    .map((key) => [key, doc[key]])
+}
+
+const SKIP_FIELD_SEARCH = {
+  highlight: true,
+  clip_score: true,
+  iqr_score: true,
+  _root_: true,
+  _version_: true,
+  text: true,
+  text_rev: true
+}
+
+export function canSearchField(key) {
+  return Boolean(key) && !SKIP_FIELD_SEARCH[key] && /^[A-Za-z_][\w.]*$/.test(key)
+}
+
+export function valueList(val) {
+  if (Array.isArray(val)) {
+    return val.filter((item) => item != null && item !== '' && typeof item !== 'object')
+  }
+  if (val == null || val === '' || typeof val === 'object') {
+    return []
+  }
+  return [val]
+}
+
+export function fieldSearchQuery(field, value) {
+  if (!canSearchField(field) || value == null || value === '') {
+    return ''
+  }
+  const text = String(value).replace(/\\/g, '\\\\').replace(/"/g, '\\"')
+  return field + ':"' + text + '"'
+}

--- a/imagespace/web/src/filters.js
+++ b/imagespace/web/src/filters.js
@@ -1,0 +1,48 @@
+import { canSearchField, fieldSearchQuery } from './api.js'
+
+export function looksLikeFieldQuery(q) {
+  return /^[A-Za-z_][\w.]*\s*:/.test(String(q || '').trim())
+}
+
+export function sameFilter(a, b) {
+  return Boolean(a && b && a.field === b.field && String(a.value) === String(b.value))
+}
+
+export function addFilter(filters, field, value) {
+  const list = Array.isArray(filters) ? filters.slice() : []
+  if (!canSearchField(field) || value == null || value === '') {
+    return list
+  }
+  const next = { field: String(field), value: String(value) }
+  if (list.some((row) => sameFilter(row, next))) {
+    return list
+  }
+  list.push(next)
+  return list
+}
+
+export function removeFilter(filters, index) {
+  return (filters || []).filter((_, i) => i !== index)
+}
+
+export function filterClause(filter) {
+  if (!filter) {
+    return ''
+  }
+  return fieldSearchQuery(filter.field, filter.value)
+}
+
+export function filterClauses(filters) {
+  return (filters || []).map(filterClause).filter(Boolean)
+}
+
+export function filterLabel(filter) {
+  if (!filter) {
+    return ''
+  }
+  return filter.field + ': "' + filter.value + '"'
+}
+
+export function isActiveFilter(filters, field, value) {
+  return (filters || []).some((row) => sameFilter(row, { field, value }))
+}

--- a/imagespace/web/src/filters.test.js
+++ b/imagespace/web/src/filters.test.js
@@ -1,0 +1,31 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { addFilter, filterClauses, filterLabel, isActiveFilter, looksLikeFieldQuery, removeFilter } from './filters.js'
+
+test('clicking an EXIF value stacks a chip and skips duplicates', () => {
+  let filters = []
+  filters = addFilter(filters, 'Exif_IFD0_Artist', 'Matteo Chinellato')
+  filters = addFilter(filters, 'tiff_Make', 'Canon')
+  filters = addFilter(filters, 'Exif_IFD0_Artist', 'Matteo Chinellato')
+  assert.equal(filters.length, 2)
+  assert.deepEqual(filterClauses(filters), [
+    'Exif_IFD0_Artist:"Matteo Chinellato"',
+    'tiff_Make:"Canon"'
+  ])
+  assert.equal(filterLabel(filters[0]), 'Exif_IFD0_Artist: "Matteo Chinellato"')
+  assert.equal(isActiveFilter(filters, 'tiff_Make', 'Canon'), true)
+})
+
+test('x removes one chip and leaves the rest', () => {
+  const filters = removeFilter([
+    { field: 'tiff_Make', value: 'Canon' },
+    { field: 'tiff_Model', value: 'EOS' }
+  ], 0)
+  assert.deepEqual(filters, [{ field: 'tiff_Model', value: 'EOS' }])
+})
+
+test('a field:"value" in the search box is a field query; OCR text is not', () => {
+  assert.equal(looksLikeFieldQuery('Exif_IFD0_Artist:"Matteo Chinellato"'), true)
+  assert.equal(looksLikeFieldQuery('Elisa'), false)
+  assert.equal(looksLikeFieldQuery('*'), false)
+})

--- a/imagespace/web/src/main.js
+++ b/imagespace/web/src/main.js
@@ -1,0 +1,5 @@
+import { createApp } from 'vue'
+import App from './App.vue'
+import './style.css'
+
+createApp(App).mount('#app')

--- a/imagespace/web/src/style.css
+++ b/imagespace/web/src/style.css
@@ -1,0 +1,322 @@
+:root {
+  --ink: #1c1917;
+  --muted: #78716c;
+  --line: #e7e5e4;
+  --paper: #fafaf9;
+  --card: #ffffff;
+  --copper: #9a3412;
+  --copper-dark: #7c2d12;
+  --tray: #f5f5f4;
+  font-family: "Source Sans 3", "Segoe UI", Helvetica, Arial, sans-serif;
+  color: var(--ink);
+  background: var(--paper);
+}
+
+* { box-sizing: border-box; }
+html, body, #app { margin: 0; min-height: 100%; background: var(--paper); }
+a { color: var(--copper); text-decoration: none; }
+a:hover { text-decoration: underline; }
+button, input { font-family: inherit; }
+button {
+  cursor: pointer;
+  border: 0;
+  border-radius: 4px;
+  padding: 0.4rem 0.85rem;
+  font-size: 0.88rem;
+  font-weight: 600;
+  background: var(--copper);
+  color: #fff8f3;
+}
+button:hover:not(:disabled) { background: var(--copper-dark); }
+button.ghost {
+  background: transparent;
+  color: var(--copper);
+  border: 1px solid var(--copper);
+}
+button:disabled { opacity: 0.45; cursor: not-allowed; }
+
+.shell {
+  display: grid;
+  grid-template-columns: 11rem 1fr;
+  min-height: 100vh;
+}
+.tray {
+  background: var(--tray);
+  border-right: 1px solid var(--line);
+  padding: 0.75rem 0.6rem;
+  overflow: auto;
+}
+.tray h2 { font-size: 0.82rem; margin: 0 0 0.5rem; letter-spacing: 0.04em; text-transform: uppercase; color: var(--muted); }
+.tray .empty { font-size: 0.8rem; color: var(--muted); }
+.tray-item {
+  display: block;
+  width: 100%;
+  margin: 0 0 0.45rem;
+  padding: 0;
+  background: none;
+  border: 1px solid var(--line);
+  border-radius: 3px;
+  overflow: hidden;
+}
+.tray-item img { display: block; width: 100%; height: 5.5rem; object-fit: cover; }
+.tray-item.active { outline: 2px solid var(--copper); }
+
+.main { display: flex; flex-direction: column; min-width: 0; }
+.mast {
+  display: flex;
+  align-items: flex-start;
+  gap: 1rem;
+  padding: 0.7rem 1rem;
+  border-bottom: 1px solid var(--line);
+  background: var(--card);
+}
+.mast h1 { margin: 0; font-size: 1.15rem; }
+.mast p { margin: 0; font-size: 0.78rem; color: var(--muted); }
+.search-stack {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+.search {
+  display: flex;
+  gap: 0.4rem;
+}
+.filters {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.35rem;
+}
+.chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.2rem;
+  max-width: 100%;
+  background: #f5f0ea;
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  padding: 0.12rem 0.15rem 0.12rem 0.6rem;
+  font-size: 0.78rem;
+}
+.chip-text {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  max-width: 22rem;
+}
+.chip-x, .chip-add {
+  width: 1.25rem;
+  height: 1.25rem;
+  padding: 0;
+  border-radius: 999px;
+  line-height: 1.15;
+  font-size: 0.95rem;
+  font-weight: 700;
+}
+.chip-add {
+  background: transparent;
+  color: var(--copper);
+  border: 1px solid var(--copper);
+}
+.chip-new {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+}
+.chip-new input {
+  width: 9rem;
+  border: 1px solid var(--line);
+  border-radius: 4px;
+  padding: 0.2rem 0.4rem;
+  font-size: 0.8rem;
+}
+.search input {
+  flex: 1;
+  border: 1px solid var(--line);
+  border-radius: 4px;
+  padding: 0.4rem 0.6rem;
+  font-size: 0.95rem;
+}
+.query-wrap {
+  position: relative;
+  flex: 0 0 auto;
+}
+.query-image {
+  display: flex;
+  align-items: center;
+  gap: 0.55rem;
+  max-width: 16rem;
+  padding: 0.15rem 1.4rem 0.15rem 0.15rem;
+  background: var(--paper);
+  color: var(--ink);
+  border: 1px solid var(--copper);
+  text-align: left;
+  font-weight: 600;
+}
+.query-clear {
+  position: absolute;
+  top: -0.35rem;
+  right: -0.35rem;
+  width: 1.35rem;
+  height: 1.35rem;
+  padding: 0;
+  border-radius: 999px;
+  line-height: 1.2;
+  font-size: 1rem;
+  font-weight: 700;
+}
+.query-image img {
+  width: 3.4rem;
+  height: 3.4rem;
+  object-fit: cover;
+  border-radius: 3px;
+  background: var(--line);
+}
+.query-image span { font-size: 0.78rem; line-height: 1.2; overflow: hidden; }
+.query-image em {
+  display: block;
+  font-style: normal;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--copper);
+  font-size: 0.68rem;
+}
+
+.status { padding: 0.4rem 1rem; font-size: 0.85rem; color: var(--muted); }
+.iqr-bar {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0 1rem 0.5rem;
+  font-size: 0.85rem;
+  color: var(--muted);
+}
+.tile.pos { outline: 2px solid #3f6212; }
+.tile.neg { outline: 2px solid #9f1239; }
+.actions button.on {
+  background: var(--copper);
+  color: #fff8f3;
+}
+.banner { margin: 0; padding: 0.5rem 1rem; background: #fef2f2; color: #9f1239; }
+
+.grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(min(100%, 13.5rem), 1fr));
+  gap: 0.7rem;
+  padding: 0.8rem 1rem 1.4rem;
+}
+.tile {
+  background: var(--card);
+  border: 1px solid var(--line);
+  border-radius: 4px;
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+}
+.tile img {
+  width: 100%;
+  height: 9rem;
+  object-fit: cover;
+  background: #e7e5e4;
+  cursor: pointer;
+  border-radius: 4px 4px 0 0;
+}
+.tile .actions {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 0.25rem;
+  padding: 0.35rem;
+  min-width: 0;
+}
+.tile .actions button {
+  min-width: 0;
+  padding: 0.28rem 0.15rem;
+  font-size: 0.7rem;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.tile .ocr {
+  margin: 0;
+  padding: 0 0.4rem 0.4rem;
+  font-size: 0.75rem;
+  color: var(--muted);
+  max-height: 2.4rem;
+  overflow: hidden;
+}
+
+.more { margin: 0 1rem 1.2rem; }
+
+.detail {
+  position: fixed;
+  inset: 0;
+  background: rgba(28, 25, 23, 0.45);
+  display: flex;
+  justify-content: center;
+  align-items: flex-start;
+  padding: 2rem 1rem;
+  overflow: auto;
+  z-index: 20;
+}
+.detail-card {
+  background: var(--card);
+  border-radius: 6px;
+  max-width: 52rem;
+  width: 100%;
+  min-width: 0;
+  padding: 1rem 1.1rem 1.3rem;
+}
+.detail-top {
+  display: grid;
+  grid-template-columns: minmax(0, 16rem) minmax(0, 1fr);
+  gap: 1rem;
+  align-items: start;
+}
+.detail-top > div { min-width: 0; }
+.detail-top img { width: 100%; border-radius: 4px; background: #e7e5e4; }
+.detail dl { margin: 0.8rem 0 0; }
+.detail dt { font-size: 0.75rem; color: var(--muted); margin-top: 0.45rem; }
+.detail dd { margin: 0.1rem 0 0; font-size: 0.88rem; word-break: break-all; }
+.field-hit {
+  display: inline;
+  margin: 0 0.55rem 0 0;
+  padding: 0;
+  background: none;
+  color: var(--copper);
+  font-weight: 600;
+  font-size: inherit;
+  border: 0;
+  border-radius: 0;
+}
+.field-hit:hover:not(:disabled) {
+  background: none;
+  text-decoration: underline;
+}
+.field-hit.on {
+  text-decoration: underline;
+}
+.detail .row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+  margin-top: 0.6rem;
+}
+.detail .row button {
+  flex: 0 1 auto;
+  white-space: nowrap;
+}
+
+@media (max-width: 720px) {
+  .shell { grid-template-columns: 1fr; }
+  .tray { display: flex; gap: 0.4rem; overflow-x: auto; border-right: 0; border-bottom: 1px solid var(--line); }
+  .tray-item { width: 5.5rem; flex: 0 0 auto; }
+  .detail-top { grid-template-columns: 1fr; }
+  .grid { grid-template-columns: repeat(auto-fill, minmax(min(100%, 10.25rem), 1fr)); }
+  .tile .actions { grid-template-columns: repeat(3, minmax(0, 1fr)); }
+}
+@media (max-width: 480px) {
+  .grid { grid-template-columns: minmax(0, 1fr); }
+}

--- a/imagespace/web/src/tray.js
+++ b/imagespace/web/src/tray.js
@@ -1,0 +1,29 @@
+const KEY = 'imagespace.tray.v1'
+
+export function loadTray() {
+  try {
+    const raw = JSON.parse(localStorage.getItem(KEY) || '[]')
+    return Array.isArray(raw) ? raw.filter((row) => row && row.id) : []
+  } catch (e) {
+    return []
+  }
+}
+
+export function saveTray(rows) {
+  localStorage.setItem(KEY, JSON.stringify(rows))
+}
+
+export function inTray(rows, id) {
+  return rows.some((row) => row.id === id)
+}
+
+export function toggleTray(rows, doc) {
+  if (!doc || !doc.id) {
+    return rows
+  }
+  if (inTray(rows, doc.id)) {
+    return rows.filter((row) => row.id !== doc.id)
+  }
+  const next = rows.concat([{ id: doc.id, content_type: doc.content_type }])
+  return next
+}

--- a/imagespace/web/vite.config.js
+++ b/imagespace/web/vite.config.js
@@ -1,0 +1,15 @@
+import { defineConfig } from 'vite'
+import vue from '@vitejs/plugin-vue'
+
+export default defineConfig({
+  plugins: [vue()],
+  server: {
+    port: 5173,
+    proxy: {
+      '/api': {
+        target: 'http://127.0.0.1:8090',
+        changeOrigin: true
+      }
+    }
+  }
+})

--- a/pge/src/main/resources/bin/index-imagespace-fgbg/index-imagespace-fgbg.sh
+++ b/pge/src/main/resources/bin/index-imagespace-fgbg/index-imagespace-fgbg.sh
@@ -1,21 +1,29 @@
 #!/usr/bin/env bash
 # Incremental CLIP foreground/background indexes after ImageCat ingest.
-# No-op unless IMAGE_SPACE_HOME is set. Needs rembg in the embed venv.
+# Defaults to $OODT_HOME/imagespace. Needs rembg in the ImageCat venv.
 set -euo pipefail
+
+if [ -z "${IMAGE_SPACE_HOME:-}" ] && [ -n "${OODT_HOME:-}" ]; then
+  IMAGE_SPACE_HOME=$OODT_HOME/imagespace
+fi
 
 if [ -z "${IMAGE_SPACE_HOME:-}" ]; then
   echo "urn:memex:IndexImageSpaceFgBg: IMAGE_SPACE_HOME is unset; skip fg/bg CLIP"
   exit 0
 fi
 
-if [ ! -d "$IMAGE_SPACE_HOME" ]; then
-  echo "urn:memex:IndexImageSpaceFgBg: IMAGE_SPACE_HOME=$IMAGE_SPACE_HOME is not a directory" >&2
-  exit 1
+if [ ! -d "$IMAGE_SPACE_HOME/server" ]; then
+  echo "urn:memex:IndexImageSpaceFgBg: no server at $IMAGE_SPACE_HOME; skip fg/bg CLIP"
+  exit 0
 fi
 
 pick_python() {
   if [ -n "${IMAGE_SPACE_PYTHON:-}" ]; then
     echo "$IMAGE_SPACE_PYTHON"
+    return
+  fi
+  if [ -x "${OODT_HOME:-}/.venv/bin/python" ]; then
+    echo "$OODT_HOME/.venv/bin/python"
     return
   fi
   if [ -x "$IMAGE_SPACE_HOME/.venv-embed/bin/python" ]; then
@@ -31,6 +39,9 @@ PY=$(pick_python)
 
 export IMAGE_SPACE_SOLR="$SOLR_URL"
 export PYTHONPATH="$IMAGE_SPACE_HOME"
+if [ -n "${OODT_HOME:-}" ]; then
+  export IMAGE_SPACE_DATA="${IMAGE_SPACE_DATA:-$OODT_HOME/data/imagespace}"
+fi
 # JobDir is cwd when the PGE starts us; python cds to IMAGE_SPACE_HOME.
 export PGE_PROGRESS_DIR="${PGE_PROGRESS_DIR:-$PWD}"
 cd "$IMAGE_SPACE_HOME"

--- a/pge/src/main/resources/bin/index-imagespace/index-imagespace.sh
+++ b/pge/src/main/resources/bin/index-imagespace/index-imagespace.sh
@@ -1,21 +1,29 @@
 #!/usr/bin/env bash
 # Incremental CLIP/FAISS after ImageCat ingest.
-# No-op unless IMAGE_SPACE_HOME is set.
+# Defaults to $OODT_HOME/imagespace (packed in the distro). Skip if missing.
 set -euo pipefail
+
+if [ -z "${IMAGE_SPACE_HOME:-}" ] && [ -n "${OODT_HOME:-}" ]; then
+  IMAGE_SPACE_HOME=$OODT_HOME/imagespace
+fi
 
 if [ -z "${IMAGE_SPACE_HOME:-}" ]; then
   echo "urn:memex:IndexImageSpace: IMAGE_SPACE_HOME is unset; skip CLIP rebuild"
   exit 0
 fi
 
-if [ ! -d "$IMAGE_SPACE_HOME" ]; then
-  echo "urn:memex:IndexImageSpace: IMAGE_SPACE_HOME=$IMAGE_SPACE_HOME is not a directory" >&2
-  exit 1
+if [ ! -d "$IMAGE_SPACE_HOME/server" ]; then
+  echo "urn:memex:IndexImageSpace: no server at $IMAGE_SPACE_HOME; skip CLIP rebuild"
+  exit 0
 fi
 
 pick_python() {
   if [ -n "${IMAGE_SPACE_PYTHON:-}" ]; then
     echo "$IMAGE_SPACE_PYTHON"
+    return
+  fi
+  if [ -x "${OODT_HOME:-}/.venv/bin/python" ]; then
+    echo "$OODT_HOME/.venv/bin/python"
     return
   fi
   if [ -x "$IMAGE_SPACE_HOME/.venv-embed/bin/python" ]; then
@@ -31,6 +39,9 @@ PY=$(pick_python)
 
 export IMAGE_SPACE_SOLR="$SOLR_URL"
 export PYTHONPATH="$IMAGE_SPACE_HOME"
+if [ -n "${OODT_HOME:-}" ]; then
+  export IMAGE_SPACE_DATA="${IMAGE_SPACE_DATA:-$OODT_HOME/data/imagespace}"
+fi
 # JobDir is cwd when the PGE starts us; python cds to IMAGE_SPACE_HOME.
 export PGE_PROGRESS_DIR="${PGE_PROGRESS_DIR:-$PWD}"
 cd "$IMAGE_SPACE_HOME"

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,11 @@ Pillow>=10.0.0
 transformers>=4.40.0,<5
 sentencepiece>=0.2.0
 torch>=2.2.0
+
+# ImageSpace API (FastAPI sidecar). CLIP/IQR extras are in
+# imagespace/requirements-embed.txt and requirements-iqr.txt.
+fastapi>=0.110
+uvicorn[standard]>=0.27
+httpx>=0.27
+numpy>=1.24
+faiss-cpu>=1.8.0

--- a/tests/test_imagespace_config.py
+++ b/tests/test_imagespace_config.py
@@ -1,0 +1,49 @@
+"""ImageSpace data paths follow OODT_HOME when installed in ImageCat."""
+
+import os
+import unittest
+
+ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+IS = os.path.join(ROOT, "imagespace")
+
+
+class DataRootTests(unittest.TestCase):
+    def setUp(self):
+        import sys
+        from importlib import reload
+        if IS not in sys.path:
+            sys.path.insert(0, IS)
+        for key in ("IMAGE_SPACE_DATA", "OODT_HOME", "IMAGECAT_HOME", "IMAGE_SPACE_INDEX_DIR"):
+            os.environ.pop(key, None)
+        from server import config
+        reload(config)
+        self.config = config
+
+    def test_standalone_defaults_to_data(self):
+        self.assertEqual(self.config.data_root(), "data")
+        self.assertEqual(self.config.index_dir(), os.path.join("data", "clip"))
+
+    def test_oodt_home_uses_data_imagespace(self):
+        from importlib import reload
+        os.environ["OODT_HOME"] = "/opt/imagecat"
+        reload(self.config)
+        self.assertEqual(self.config.data_root(), "/opt/imagecat/data/imagespace")
+        self.assertEqual(self.config.fg_dir(), "/opt/imagecat/data/imagespace/fg")
+        self.assertEqual(self.config.thumb_dir(), "/opt/imagecat/data/imagespace/thumbs")
+
+    def test_explicit_data_wins(self):
+        from importlib import reload
+        os.environ["OODT_HOME"] = "/opt/imagecat"
+        os.environ["IMAGE_SPACE_DATA"] = "/tmp/is"
+        reload(self.config)
+        self.assertEqual(self.config.data_root(), "/tmp/is")
+        self.assertEqual(self.config.index_dir(), os.path.join("/tmp/is", "clip"))
+
+
+    def test_query_helpers_still_import(self):
+        from server.solr import user_query
+        self.assertEqual(user_query("*"), "*:*")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_pge_python.py
+++ b/tests/test_pge_python.py
@@ -55,10 +55,12 @@ class ChunkFileTests(unittest.TestCase):
         env = os.environ.copy()
         env.pop("IMAGE_SPACE_HOME", None)
         env.pop("IMAGE_SPACE_PYTHON", None)
+        env.pop("OODT_HOME", None)
+        env.pop("IMAGECAT_HOME", None)
         for name in ("index-imagespace", "index-imagespace-fgbg"):
             script = os.path.join(PGE_BIN, name, name + ".sh")
             out = subprocess.check_output(["bash", script], env=env, text=True)
-            self.assertIn("unset; skip", out)
+            self.assertIn("skip", out)
 
     def test_chunkfile_extractor_labels_are_imagecat(self):
         path = os.path.join(


### PR DESCRIPTION
## Why

ImageSpace is ImageCat’s analyst desktop. A second repo (\`chrismattmann/image_space\`) plus a local-only \`IMAGE_SPACE_HOME\` was leftover from Girder/SMQTK. CLIP ingest PGEs already belong to ImageCat.

## What

- \`imagespace/\` module (Vue 3 + FastAPI, not the NASA Girder tree).
- Packed into the RADiX tarball. \`bin/oodt start\` starts FastAPI on **8090** (Solr-shaped sidecar, not a WAR).
- \`bin/setenv.sh\` sets \`IMAGE_SPACE_HOME=\$IMAGECAT_HOME/imagespace\`. Indexes under \`\$OODT_HOME/data/imagespace/\`.
- \`bin/imagecat-setup\` installs API deps and builds the Vue UI.
- Ingest hooks default to the in-tree module; skip if it is missing.

The NASA \`image_space\` clone is unchanged. \`chrismattmann/image_space\` gets a README pointer.

UI: http://127.0.0.1:8090/ after \`bin/imagecat-setup && bin/oodt start\`.