### PR TITLE
Install Keras for IQR and describe ImageSpace in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,14 @@ OPSUI is the Vue 3 console from Mnemosyne, overlaid at `/opsui/`. Solr runs as
 its own process (not a Tomcat war) with two cores: `imagecat` (OCR text) and
 `oodt-fm` (File Manager catalog).
 
+[ImageSpace](imagespace/README.md) is the analyst desktop in this same tarball:
+search OCR and Tika fields, browse the image grid, CLIP similar, foreground /
+background similar (U2-Net / rembg), and IQR (a tiny Keras head fitted at
+Refine time on CLIP vectors). `bin/oodt start` brings it up on port 8090
+the way it starts Solr — FastAPI, not a WAR. CLIP / fg / bg indexes live
+under `$IMAGECAT_HOME/data/imagespace/`. The NASA Girder/SMQTK ImageSpace
+is a different tree.
+
 See [docs/WHAT-IS-IN.md](docs/WHAT-IS-IN.md) for keep / throw / replace.
 
 Build
@@ -28,8 +36,8 @@ mvn -B package
 tar xzf distribution/target/oodt-distribution-0.1-bin.tar.gz
 cd <unpacked>
 export IMAGECAT_HOME=$PWD
-bin/imagecat-setup          # pysolr + transformers + torch into .venv
-bin/oodt start              # File Manager, Workflow, Resource, Tomcat 9, Solr 10
+bin/imagecat-setup          # .venv (OCR, CLIP, Keras IQR) + Vue build
+bin/oodt start              # File Manager, Workflow, Resource, Tomcat 9, Solr 10, ImageSpace
 ```
 
 - OPSUI: `http://localhost:8080/opsui/`
@@ -48,18 +56,26 @@ Tika runs on each image in that same script (MIME, EXIF, IPTC) so the
 and Solr Cell are gone. The old `solrcell_ingest` name remains as a shim
 onto the same script.
 
-ImageSpace (analyst UI, CLIP, fg/bg, IQR) ships in this tarball. `bin/oodt start`
-brings it up on `http://127.0.0.1:8090/` (FastAPI, like Solr). After ingest,
-`urn:memex:IndexImageSpace` increments CLIP/FAISS and
-`urn:memex:IndexImageSpaceFgBg` increments foreground/background CLIP
-(U2-Net / rembg). Indexes live under `$IMAGECAT_HOME/data/imagespace/`.
-
 ```bash
 python3 pge/bin/imagecat-ocr/imagecat-ocr.py \
   -f data/archive/chunks/0/filelist_chunk_0.txt \
   -s http://localhost:8983/solr/imagecat \
   --model trocr
 ```
+
+ImageSpace
+----------
+
+After OCR, the same ingest workflow increments CLIP/FAISS
+(`urn:memex:IndexImageSpace`) and foreground/background CLIP
+(`urn:memex:IndexImageSpaceFgBg`). The UI at
+`http://127.0.0.1:8090/` searches Solr, shows the pictures, and
+runs Similar / FG / BG against those indexes. IQR is not a pretrained
+model: mark tiles + / − and Refine fits a small Keras head (Torch
+backend) on the CLIP vectors you already have.
+
+`bin/imagecat-setup` installs Keras with the rest of the Python env
+and builds the Vue UI. Vite on 5173 is optional for UI development.
 
 See the wiki for more on installing and running ImageCat:
 * [Installation instructions](https://github.com/chrismattmann/imagecat/wiki/Installation)

--- a/distribution/src/main/resources/bin/imagecat-setup
+++ b/distribution/src/main/resources/bin/imagecat-setup
@@ -34,13 +34,10 @@ fi
 "$VENV/bin/python" -m pip install --upgrade pip
 "$VENV/bin/python" -m pip install -r "$REQ"
 if [ -f "$IMAGECAT_HOME/imagespace/requirements-embed.txt" ]; then
-  (cd "$IMAGECAT_HOME/imagespace" && "$VENV/bin/python" -m pip install -r requirements-embed.txt) || \
-    echo "CLIP extra (torch) already covered by requirements.txt or failed; CLIP ingest needs it" >&2
+  (cd "$IMAGECAT_HOME/imagespace" && "$VENV/bin/python" -m pip install -r requirements-embed.txt)
 fi
-if [ -f "$IMAGECAT_HOME/imagespace/requirements-iqr.txt" ]; then
-  (cd "$IMAGECAT_HOME/imagespace" && "$VENV/bin/python" -m pip install -r requirements-iqr.txt) || \
-    echo "IQR extra (keras) skipped; similar still works without it" >&2
-fi
+# keras is in requirements.txt (IQR head, Torch backend). Fail setup if it
+# did not land — "IQR off (needs Keras)" is not an optional extra.
 # rembg is optional; fg/bg ingest no-ops usefully if missing.
 "$VENV/bin/python" -m pip install rembg onnxruntime >/dev/null 2>&1 || \
   echo "rembg not installed; IndexImageSpaceFgBg will skip until pip install rembg onnxruntime" >&2

--- a/distribution/src/main/resources/bin/imagespace
+++ b/distribution/src/main/resources/bin/imagespace
@@ -66,6 +66,7 @@ start() {
   export IMAGE_SPACE_HOME
   export IMAGE_SPACE_DATA=${IMAGE_SPACE_DATA:-$OODT_HOME/data/imagespace}
   export IMAGE_SPACE_SOLR=${IMAGE_SPACE_SOLR:-http://localhost:8983/solr/imagecat}
+  export KERAS_BACKEND=${KERAS_BACKEND:-torch}
   export PYTHONPATH="$IMAGE_SPACE_HOME${PYTHONPATH:+:$PYTHONPATH}"
   cd "$IMAGE_SPACE_HOME"
   nohup "$PYTHON" -m uvicorn server.main:app --host 127.0.0.1 --port "$PORT" \

--- a/distribution/src/main/resources/bin/setenv.sh
+++ b/distribution/src/main/resources/bin/setenv.sh
@@ -43,6 +43,8 @@ export IMAGESPACE_PORT=8090
 if [ -x "$IMAGECAT_HOME/.venv/bin/python" ]; then
   export IMAGE_SPACE_PYTHON=$IMAGECAT_HOME/.venv/bin/python
 fi
+# IQR Keras 3 uses Torch, already installed for CLIP/TrOCR.
+export KERAS_BACKEND=${KERAS_BACKEND:-torch}
 
 # Bound every Avro client call (Mnemosyne #197). Ten minutes is the code
 # default; 0 waits forever. JDK_JAVA_OPTIONS reaches File Manager, Workflow

--- a/imagespace/requirements-iqr.txt
+++ b/imagespace/requirements-iqr.txt
@@ -1,4 +1,4 @@
-# Python 3.9+ (Keras 3). The search-only 3.8 venv does not include this.
+# IQR uses Keras 3 on the Torch backend (already in ImageCat).
+# bin/imagecat-setup installs keras via the top-level requirements.txt.
 -r requirements.txt
 keras>=3.0
-tensorflow>=2.16

--- a/imagespace/server/iqr.py
+++ b/imagespace/server/iqr.py
@@ -1,17 +1,26 @@
 """Tiny Keras head for Interactive Query Refinement.
 
 CLIP vectors stay on disk. This ranker maps a CLIP vector to P(relevant).
+The head is fitted at Refine time; Keras is the library, not a pretrained
+IQR model. Use the Torch backend (already in ImageCat for CLIP/TrOCR)
+so the distro does not pull TensorFlow.
 """
 
 from __future__ import annotations
 
+import os
 from functools import lru_cache
 
 DEFAULT_DIM = 512
 
 
+def _use_torch_backend():
+    os.environ.setdefault("KERAS_BACKEND", "torch")
+
+
 @lru_cache(maxsize=1)
 def keras_available() -> bool:
+    _use_torch_backend()
     try:
         import keras  # noqa: F401
         return True
@@ -24,6 +33,7 @@ def keras_available() -> bool:
 
 
 def _layers():
+    _use_torch_backend()
     try:
         from keras import Sequential, layers
         return Sequential, layers

--- a/imagespace/web/src/App.vue
+++ b/imagespace/web/src/App.vue
@@ -50,7 +50,7 @@
       <p class="status">{{ statusLine }}</p>
       <div class="iqr-bar">
         <span v-if="canIqr">IQR {{ iqrPos.length }} relevant / {{ iqrNeg.length }} not</span>
-        <span v-else title="Python 3.9+ with Keras and TensorFlow">IQR off (needs Keras)</span>
+        <span v-else title="Keras 3 (Torch backend) is not installed in this ImageSpace process">IQR off (needs Keras)</span>
         <button :disabled="!canIqr || !iqrPos.length || !iqrNeg.length || loading" title="Fit the Keras head on CLIP vectors and rerank" @click="runIqr">Refine</button>
         <button class="ghost" :disabled="!iqrPos.length && !iqrNeg.length && !iqrActive" @click="clearIqr">Clear labels</button>
       </div>

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,10 +9,12 @@ transformers>=4.40.0,<5
 sentencepiece>=0.2.0
 torch>=2.2.0
 
-# ImageSpace API (FastAPI sidecar). CLIP/IQR extras are in
-# imagespace/requirements-embed.txt and requirements-iqr.txt.
+# ImageSpace API (FastAPI sidecar). CLIP extras are in
+# imagespace/requirements-embed.txt. IQR is Keras 3 on the Torch
+# backend we already ship for TrOCR/CLIP — not a pretrained model.
 fastapi>=0.110
 uvicorn[standard]>=0.27
 httpx>=0.27
 numpy>=1.24
 faiss-cpu>=1.8.0
+keras>=3.0


### PR DESCRIPTION
Follow-up to #55 (already merged).

Those two commits were pushed onto `imagespace-in-distro` *after* the merge, so they never reached master. A merged PR cannot be updated.

## What

- **Keras is a distro dependency.** CLIP ingest builds vectors; IQR Refine fits a tiny Keras head at click time (Torch backend, no TensorFlow). `requirements.txt` includes `keras`; `imagecat-setup` no longer skips it.
- **README** opening blurb + ImageSpace section (8090, CLIP/fg/bg, IQR).

Live 8090 already has Keras (`iqr: true`). This is the git copy of that.