### PR TITLE
Put the ImageCat / ImageSpace roadmap back for review

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,8 @@ the way it starts Solr — FastAPI, not a WAR. CLIP / fg / bg indexes live
 under `$IMAGECAT_HOME/data/imagespace/`. This is new work inspired by
 NASA JPL's efforts on the DARPA MEMEX program.
 
-See [docs/WHAT-IS-IN.md](docs/WHAT-IS-IN.md) for keep / throw / replace.
+See [docs/WHAT-IS-IN.md](docs/WHAT-IS-IN.md) for keep / throw / replace
+and [docs/roadmap.md](docs/roadmap.md) for where we are and what is next.
 
 Build
 -----

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,0 +1,53 @@
+# ImageCat / ImageSpace roadmap
+
+ImageCat is the ingest pipeline. ImageSpace is the analyst desktop (now
+in this tarball). OPSUI (Mnemosyne) is how we watch the jobs.
+
+The product path is in. Wiki Installation / How to Run match `bin/imagecat-setup`
+plus `bin/oodt start` plus ImageSpace on **8090**.
+
+## Where we started
+
+RADiX ingest (chunk → OCR/Tika → Solr) and OPSUI for jobs. Similarity,
+fg/bg, IQR, and “watch it in OPSUI” were missing or bolted on with a
+local `IMAGE_SPACE_HOME`. ImageSpace was a second repo.
+
+## Slice / where
+
+| Slice | Where |
+| --- | --- |
+| CLIP/FAISS ingest hook + thumbs | ImageSpace #1, #2 |
+| Field search, FG/BG similar, load-more, clear-X | ImageSpace #3 |
+| Concurrent CLIP/FG-BG write lock | ImageSpace #4 |
+| EXIF filter chips | ImageSpace #5 |
+| `.progress` from CLIP/FG-BG | ImageSpace #6 |
+| Card actions stay on the tile | ImageSpace #7 |
+| IndexImageSpace + IndexImageSpaceFgBg on IngestInPlace | ImageCat #50–#54 |
+| ImageSpace in the ImageCat tarball (`oodt start` → :8090) | ImageCat #55 |
+| Keras IQR in the distro; README ImageSpace section | ImageCat #56 |
+| MEMEX credit (no second-tree pointer) | ImageCat #57 |
+| PGE Peek, progress bar, W1 `PGE EXEC` stamp, wall clock | Mnemosyne #262, #265, #270, #256 |
+| Wiki Installation / How to Run / Interacting | [imagecat wiki](https://github.com/chrismattmann/imagecat/wiki) |
+
+## Live (this box)
+
+- Solr `imagecat` **653** (CTCEU + ice JPGs; PDFs skipped)
+- CLIP + fg/bg + IQR **on** at http://127.0.0.1:8090/
+- OPSUI http://localhost:8080/opsui/
+- W1 `ThreadPoolWorkflowEngineFactory` (do not switch to W2)
+- DRAT **9000/9001**; ImageCat FM/WM **9100/9101**
+- Mnemosyne #270 is on the live WM (`PGE EXEC` while a PGE runs)
+
+## Next
+
+1. ~~Wiki / How to Run~~ **done**
+2. **One clean unpack** — rebuild the tarball and start from it so live is not a pile of overlays
+3. **Leave settled-condition unwired** until IngestInPlace is fanned out across chunks; sequential CLIP already waits. A fan-out would want a Solr settle, not FM `ChunkList`
+4. **Archive** `chrismattmann/image_space` on GitHub when the README pointer should be official
+
+Not next unless asked: W2, DRAT-in-ImageCat, wiring Mnemosyne #267.
+
+## Parked (not missing product)
+
+- **DRAT `.progress`** — done separately (Claude)
+- **Mnemosyne #267 `ProductCountSettledCondition`** — merged, not wired. Pre-condition that waits until an FM product type stops growing. ImageCat’s CLIP catalog is Solr `imagecat`, and today’s workflow is sequential, so this stays off until we fan-out ingest

--- a/imagespace/docs/roadmap.md
+++ b/imagespace/docs/roadmap.md
@@ -1,35 +1,3 @@
-# ImageSpace / ImageCat roadmap
+# Roadmap
 
-ImageSpace is the analyst desktop. ImageCat is the ingest pipeline that
-fills Solr and rebuilds CLIP / fg / bg. OPSUI (Mnemosyne) is how we watch
-the jobs.
-
-The product path is in: search, CLIP similar, fg/bg similar, IQR, ingest
-hook, and progress in OPSUI. What follows is the slice map and what is
-parked on purpose.
-
-## Slice / where
-
-| Slice | Where |
-| --- | --- |
-| CLIP/FAISS ingest hook + thumbs | ImageSpace #1, #2 |
-| Field search, FG/BG similar, load-more, clear-X | ImageSpace #3 |
-| Concurrent CLIP/FG-BG write lock | ImageSpace #4 |
-| EXIF filter chips | ImageSpace #5 |
-| `.progress` from CLIP/FG-BG | ImageSpace #6 |
-| Card actions stay on the tile | ImageSpace #7 |
-| IndexImageSpace + IndexImageSpaceFgBg on IngestInPlace | ImageCat #50–#54 |
-| PGE Peek, progress bar, W1 `PGE EXEC` stamp, wall clock | Mnemosyne #262, #265, #270, #256 |
-
-## Live (this checkout)
-
-- Solr `imagecat`, CLIP, fg, and bg indexes: last full re-ingest **666** docs
-- ImageCat stays on W1 `ThreadPoolWorkflowEngineFactory` (do not switch to W2)
-- ImageSpace UI in the distro is FastAPI at **http://127.0.0.1:8090/** (`bin/oodt start`). Vite at **5173** is optional for UI development.
-- DRAT stays on **9000/9001**; ImageCat FM/WM are **9100/9101**
-
-## Parked (not missing ImageSpace features)
-
-- **DRAT `.progress`** — done separately (Claude)
-- **Mnemosyne #267 `ProductCountSettledCondition`** — merged, not wired into ImageCat. A pre-condition on `IndexImageSpace` / `IndexImageSpaceFgBg` that waits until a File Manager product type stops growing. Useful if IngestInPlace is fanned out across chunks and CLIP should not start until the catalog is stable. Today's dynWorkflow is already sequential, and ImageCat's growing catalog for CLIP is Solr `imagecat`, not FM `ChunkList` products, so this stays unwired unless we fan-out ingest.
-- **Mnemosyne #270** — merged; redeploy onto the live ImageCat WM so OPSUI can show `PGE EXEC` instead of `STARTED` while a PGE runs
+Moved to the ImageCat tree: [docs/roadmap.md](../../docs/roadmap.md).


### PR DESCRIPTION
Wiki Installation / How to Run is done. This restores the slice map so it can be reviewed in-tree.

- \`docs/roadmap.md\` — started / slice / live / next / parked
- \`imagespace/docs/roadmap.md\` points at that file
- README links it