### PR TITLE
Write JobDir/.progress from OCR and the other Python PGEs

### DIFF
--- a/pge/src/main/resources/bin/check_failed/check_failed.py
+++ b/pge/src/main/resources/bin/check_failed/check_failed.py
@@ -23,8 +23,14 @@
 
 import getopt
 import sys
+from pathlib import Path
 
 import pysolr
+
+_BIN = Path(__file__).resolve().parent.parent
+if str(_BIN) not in sys.path:
+    sys.path.insert(0, str(_BIN))
+from progress import write_progress  # noqa: E402
 
 
 def check_image_file(filepath, client):
@@ -35,15 +41,20 @@ def check_image_file(filepath, client):
 def build_chunk_file(output_file, chunk_file, client):
     num_missed = 0
     missed_list = []
-
+    paths = []
     with open(chunk_file, "r", encoding="utf-8") as the_chunk_file:
         for filepath in the_chunk_file:
             path = filepath.strip()
-            if not path:
-                continue
-            if not check_image_file(path, client):
-                num_missed += 1
-                missed_list.append(path)
+            if path:
+                paths.append(path)
+    n = len(paths)
+    write_progress(0, max(n, 1), "check")
+    for i, path in enumerate(paths):
+        if not check_image_file(path, client):
+            num_missed += 1
+            missed_list.append(path)
+        if (i + 1) % 25 == 0 or (i + 1) == n:
+            write_progress(i + 1, n, "check")
 
     print("Num Missed    : [%s]" % num_missed)
     if num_missed > 0:

--- a/pge/src/main/resources/bin/chunk_file/chunk_file.py
+++ b/pge/src/main/resources/bin/chunk_file/chunk_file.py
@@ -23,26 +23,41 @@
 
 import getopt
 import sys
+from pathlib import Path
+
+_BIN = Path(__file__).resolve().parent.parent
+if str(_BIN) not in sys.path:
+    sys.path.insert(0, str(_BIN))
+from progress import write_progress  # noqa: E402
 
 
 def split_and_execute(chunk_file, chunk_size):
     num_chunks = 0
     file_list = []
     current_chunk_size = 0
+    total_lines = 0
+    with open(chunk_file, "r", encoding="utf-8") as the_chunk_file:
+        for _line in the_chunk_file:
+            total_lines += 1
+    write_progress(0, max(total_lines, 1), "chunk")
+    seen = 0
 
     with open(chunk_file, "r", encoding="utf-8") as the_chunk_file:
         for line in the_chunk_file:
             file_list.append(line)
             current_chunk_size += 1
+            seen += 1
             if current_chunk_size == chunk_size:
                 write_file("filelist_chunk_%s.txt" % num_chunks, file_list)
                 file_list = []
                 current_chunk_size = 0
                 num_chunks += 1
+                write_progress(seen, total_lines, "chunk")
 
     if file_list:
         write_file("filelist_chunk_%s.txt" % num_chunks, file_list)
         num_chunks += 1
+    write_progress(total_lines, max(total_lines, 1), "chunk")
 
     print("Total Chunks: %s" % num_chunks)
     return num_chunks

--- a/pge/src/main/resources/bin/imagecat-ocr/imagecat-ocr.py
+++ b/pge/src/main/resources/bin/imagecat-ocr/imagecat-ocr.py
@@ -32,6 +32,11 @@ import subprocess
 import sys
 from pathlib import Path
 
+_BIN = Path(__file__).resolve().parent.parent
+if str(_BIN) not in sys.path:
+    sys.path.insert(0, str(_BIN))
+from progress import write_progress  # noqa: E402
+
 
 TROCR_MODEL = "microsoft/trocr-base-printed"
 DONUT_MODEL = "naver-clova-ix/donut-base"
@@ -268,16 +273,20 @@ def main(argv=None) -> int:
     batch = []
     indexed = 0
     failed = 0
-    for path in paths:
+    n = len(paths)
+    write_progress(0, n, "ocr")
+    for i, path in enumerate(paths):
         if not Path(path).is_file():
             print("Missing: %s" % path, file=sys.stderr)
             failed += 1
+            write_progress(i + 1, n, "ocr")
             continue
         try:
             text = ocr(path)
         except Exception as exc:  # keep the chunk moving
             print("OCR failed %s: %s" % (path, exc), file=sys.stderr)
             failed += 1
+            write_progress(i + 1, n, "ocr")
             continue
         doc = {
             "id": path,
@@ -290,16 +299,18 @@ def main(argv=None) -> int:
         if tika_app is not None:
             doc.update(tika_metadata(path, tika_app))
         batch.append(doc)
+        write_progress(i + 1, n, "ocr")
         if len(batch) >= args.commit_every:
             index_docs(args.solr_url, batch)
             indexed += len(batch)
-            print("Posted %d / %d" % (indexed, len(paths)))
+            print("Posted %d / %d" % (indexed, n))
             batch = []
 
     if batch:
         index_docs(args.solr_url, batch)
         indexed += len(batch)
 
+    write_progress(n, n, "ocr")
     print("Indexed: %d  Failed: %d" % (indexed, failed))
     return 0 if failed == 0 else 1
 

--- a/pge/src/main/resources/bin/progress.py
+++ b/pge/src/main/resources/bin/progress.py
@@ -1,0 +1,24 @@
+# Write JobDir/.progress for OPSUI. Opt-in: scripts that never call this
+# have no bar. StdPGETaskInstance watches this file.
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+
+def progress_dir(folder=None):
+    if folder:
+        return Path(folder)
+    env = os.environ.get("PGE_PROGRESS_DIR")
+    if env:
+        return Path(env)
+    return Path(".")
+
+
+def write_progress(done, total, msg="working", folder=None):
+    path = progress_dir(folder) / ".progress"
+    path.write_text(
+        "done=%d\ntotal=%d\nmsg=%s\n" % (int(done), int(total), msg or ""),
+        encoding="utf-8",
+    )
+    return path

--- a/pge/src/main/resources/bin/sha1sum/sha1sum.py
+++ b/pge/src/main/resources/bin/sha1sum/sha1sum.py
@@ -22,8 +22,14 @@
 import getopt
 import hashlib
 import sys
+from pathlib import Path
 
 import pysolr
+
+_BIN = Path(__file__).resolve().parent.parent
+if str(_BIN) not in sys.path:
+    sys.path.insert(0, str(_BIN))
+from progress import write_progress  # noqa: E402
 
 
 def compute_sha(file_path):
@@ -38,16 +44,26 @@ def iterate_docs(solr_url):
     client = pysolr.Solr(solr_url, timeout=10)
     start = 0
     page = 1
+    total = None
+    done = 0
     while True:
         print("Searching: page: [%s]: start: [%s]" % (page, start))
         results = client.search("-sha1sum_s_md:[* TO *]", **{"start": start, "rows": 10})
+        if total is None:
+            total = int(results.hits or 0)
+            write_progress(0, max(total, 1), "sha1")
         if not results.hits or not len(results):
             break
         for doc in results:
             print("Processing: %s" % doc["id"])
             doc["sha1sum_s_md"] = compute_sha(doc["id"])
             client.add([doc], commit=True)
+            done += 1
+            write_progress(done, max(total, 1), "sha1")
         page += 1
+        start = done
+    if total is not None:
+        write_progress(done, max(total, 1), "sha1")
 
 
 def main(argv):


### PR DESCRIPTION
## What this PR adds

The overlay live had `pge/bin/progress.py` and `write_progress` in the **Python PGEs that are not ImageSpace**:

- `imagecat-ocr` → `ocr N / total`
- `chunk_file` → `chunk N / total`
- `sha1sum` → `sha1 N / total`
- `check_failed` → `check N / total`

Those never landed in git. A clean tarball ran OCR with no `JobDir/.progress`, so OPSUI `#instances/ALL` had no bar.

## What is already on master (not in this diff)

CLIP and fg/bg already write the same file. That was [PR #54](https://github.com/chrismattmann/imagecat/pull/54):

- `pge/bin/index-imagespace/index-imagespace.sh` sets `PGE_PROGRESS_DIR=$PWD` (the PGE JobDir), then `python -m server.embed --incremental`
- `imagespace/server/embed.py` → `encoded N / total`
- `pge/bin/index-imagespace-fgbg/index-imagespace-fgbg.sh` same `PGE_PROGRESS_DIR`
- `imagespace/server/embed_fgbg.py` → `split`, then `fg CLIP`, then `bg CLIP` (via `encode_paths(..., progress_msg=...)`)

Helper: `imagespace/server/progress.py` (same `done=` / `total=` / `msg=` format as `pge/bin/progress.py` here).

IngestInPlace is three tasks on one instance: OCR (this PR), then IndexImageSpace, then IndexImageSpaceFgBg (#54). The bar label changes with the current task.

Mnemosyne already watches `JobDir/.progress` and stamps instance metadata. This PR is only the missing ImageCat writers.

Live ImageCat is already patched with these scripts; this PR is so the next tarball includes them.