### PR TITLE
Do not abort ImageSpace when IQR loads Keras next to FAISS

### DIFF
--- a/distribution/src/main/resources/bin/imagespace
+++ b/distribution/src/main/resources/bin/imagespace
@@ -67,6 +67,8 @@ start() {
   export IMAGE_SPACE_DATA=${IMAGE_SPACE_DATA:-$OODT_HOME/data/imagespace}
   export IMAGE_SPACE_SOLR=${IMAGE_SPACE_SOLR:-http://localhost:8983/solr/imagecat}
   export KERAS_BACKEND=${KERAS_BACKEND:-torch}
+  # FAISS + PyTorch both ship libomp; without this, IQR aborts uvicorn on macOS.
+  export KMP_DUPLICATE_LIB_OK=${KMP_DUPLICATE_LIB_OK:-TRUE}
   export PYTHONPATH="$IMAGE_SPACE_HOME${PYTHONPATH:+:$PYTHONPATH}"
   cd "$IMAGE_SPACE_HOME"
   nohup "$PYTHON" -m uvicorn server.main:app --host 127.0.0.1 --port "$PORT" \

--- a/imagespace/server/iqr.py
+++ b/imagespace/server/iqr.py
@@ -16,6 +16,7 @@ DEFAULT_DIM = 512
 
 def _use_torch_backend():
     os.environ.setdefault("KERAS_BACKEND", "torch")
+    os.environ.setdefault("KMP_DUPLICATE_LIB_OK", "TRUE")
 
 
 @lru_cache(maxsize=1)

--- a/imagespace/server/main.py
+++ b/imagespace/server/main.py
@@ -2,6 +2,13 @@
 
 from __future__ import annotations
 
+import os
+
+# FAISS and Keras/Torch each ship libomp. Two copies abort the process on
+# macOS (OMP Error #15) the first time IQR imports Keras after CLIP is loaded.
+os.environ.setdefault("KERAS_BACKEND", "torch")
+os.environ.setdefault("KMP_DUPLICATE_LIB_OK", "TRUE")
+
 from pathlib import Path
 
 from fastapi import FastAPI, HTTPException, Query


### PR DESCRIPTION
Clicking Relevant / Refine on a live ImageCat with CLIP loaded aborted the ImageSpace process (8090). FAISS and Keras/Torch each ship `libomp`; the second init is OMP Error #15 on macOS.

FM/WM/Solr stayed up. This sets `KMP_DUPLICATE_LIB_OK=TRUE` before those imports (`server/main.py`, `iqr.py`, `bin/imagespace`).

Live ImageCat is already patched and IQR refine returns 200 without dying.