### PR TITLE
Make Paddle/RapidOCR the default OCR and split URL tokens for search

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,11 +5,14 @@ ImageCatalog
 This is a [RADiX](https://cwiki.apache.org/confluence/display/OODT/RADiX+Powered+By+OODT)
 application on [Mnemosyne](https://github.com/chrismattmann/mnemosyne) 1.11.0
 that uses [Apache Solr](https://solr.apache.org/) 10,
-[Apache Tika](https://tika.apache.org/) and HuggingFace
-[TrOCR](https://huggingface.co/microsoft/trocr-base-printed) /
-[Donut](https://huggingface.co/naver-clova-ix/donut-base)
-to ingest tens of millions of files (images, but it can be extended) in place,
-extract MIME/EXIF with Tika, and OCR them into Solr.
+[Apache Tika](https://tika.apache.org/) and
+[PaddleOCR](https://github.com/PaddlePaddle/PaddleOCR) via
+[RapidOCR](https://github.com/RapidAI/RapidOCR) (Apache 2.0 ONNX; detect then
+recognize) to ingest tens of millions of files (images, but it can be
+extended) in place, extract MIME/EXIF with Tika, and OCR them into Solr.
+HuggingFace [TrOCR](https://huggingface.co/microsoft/trocr-base-printed) and
+[Donut](https://huggingface.co/naver-clova-ix/donut-base) remain as `--model`
+options.
 
 OPSUI is the Vue 3 console from Mnemosyne, overlaid at `/opsui/`. Solr runs as
 its own process (not a Tomcat war) with two cores: `imagecat` (OCR text) and
@@ -50,7 +53,9 @@ OCR
 ---
 
 The IngestInPlace PGE calls `imagecat-ocr.py` over each chunk file.
-`--model trocr` (default) is printed/scene text;
+`--model paddle` (default) is PP-OCR detect-then-recognize: no text boxes
+means empty `ocr_text`, not a hallucinated receipt word.
+`--model trocr` is a printed line recognizer;
 `--model donut` is document understanding and also fills `caption`.
 Tika runs on each image in that same script (MIME, EXIF, IPTC) so the
 `imagecat` Solr core has the metadata Solr Cell used to attach. Tesseract
@@ -61,7 +66,7 @@ onto the same script.
 python3 pge/bin/imagecat-ocr/imagecat-ocr.py \
   -f data/archive/chunks/0/filelist_chunk_0.txt \
   -s http://localhost:8983/solr/imagecat \
-  --model trocr
+  --model paddle
 ```
 
 ImageSpace

--- a/docs/WHAT-IS-IN.md
+++ b/docs/WHAT-IS-IN.md
@@ -38,7 +38,7 @@ into Solr, File Manager catalogs the files. The stack under it is new.
 | Wicket OPSUI | Vue 3 OPSUI from Mnemosyne (`pcs-opsui` WAR overlay) |
 | Solr 4.10 + Solr Cell `/update/extract` | Solr 10, cores `imagecat` and `oodt-fm`, JSON `/update` |
 | Tomcat 7 | Tomcat 9.0.7 (OPSUI / pcs-services / fmprod only) |
-| Tesseract | HuggingFace TrOCR (`microsoft/trocr-base-printed`) or Donut (`naver-clova-ix/donut-base`) via `pge/bin/imagecat-ocr/imagecat-ocr.py` |
+| Tesseract | Paddle/RapidOCR PP-OCR (`--model paddle`, default) via `pge/bin/imagecat-ocr/imagecat-ocr.py`; TrOCR and Donut remain as options |
 | `solrcell_ingest` curl loop | same name, now a shim onto `imagecat-ocr.py` |
 | `python2.7` shebangs and `print` / `long()` | Python 3 |
 

--- a/imagespace/docs/WHAT-IS-IN.md
+++ b/imagespace/docs/WHAT-IS-IN.md
@@ -34,5 +34,5 @@ it and shows the pictures.
 | CMU Caffe segmentation | U2-Net (`rembg`) fg/bg CLIP indexes |
 | Girder Private folder | `localStorage` tray |
 
-Vision transformers stay on Torch + HuggingFace, same as ImageCat TrOCR.
+Vision transformers stay on Torch + HuggingFace, same as ImageCat CLIP.
 The IQR ranker is a small Keras dense head, not a second vision stack.

--- a/pge/src/main/resources/bin/imagecat-ocr/imagecat-ocr.py
+++ b/pge/src/main/resources/bin/imagecat-ocr/imagecat-ocr.py
@@ -14,11 +14,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-# OCR a chunk file of image paths with HuggingFace TrOCR (printed/scene
-# text) or Donut (documents), then POST the text plus Tika MIME/EXIF to
-# Solr. Replaces Solr Cell + Tesseract. Solr Cell used to run Tika on
-# each image as it indexed; File Manager only catalogs the ChunkList
-# path files, so Tika has to happen here.
+# OCR a chunk file of image paths with Paddle/RapidOCR (detect then
+# recognize; default), HuggingFace TrOCR, or Donut, then POST the text
+# plus Tika MIME/EXIF to Solr. Replaces Solr Cell + Tesseract. Solr Cell
+# used to run Tika on each image as it indexed; File Manager only
+# catalogs the ChunkList path files, so Tika has to happen here.
 
 """OCR images listed in a chunk file and index the text plus Tika metadata in Solr."""
 
@@ -40,6 +40,9 @@ from progress import write_progress  # noqa: E402
 
 TROCR_MODEL = "microsoft/trocr-base-printed"
 DONUT_MODEL = "naver-clova-ix/donut-base"
+# RapidOCR ships PP-OCR ONNX (Apache 2.0). Detect-then-recognize: no
+# boxes means empty text, unlike TrOCR which always emits a token.
+PADDLE_MODEL = "rapidocr/pp-ocr"
 MAX_TIKA_VALUE = 1024
 # ICC curves, padding, and per-component JPEG tables are not what SolrCell
 # users looked at, and they blow up a string field.
@@ -179,11 +182,55 @@ def tika_metadata(path: str, tika_app: Path | None) -> dict[str, str]:
     return parse_tika_metadata_text(proc.stdout)
 
 
+def texts_from_paddle(result) -> str:
+    """Join RapidOCR / PP-OCR detections. Empty if the detector found nothing."""
+    if result is None:
+        return ""
+    txts = getattr(result, "txts", None)
+    if txts is not None:
+        lines = [str(t).strip() for t in txts if t and str(t).strip()]
+        return "\n".join(lines)
+    if isinstance(result, tuple) and result:
+        result = result[0]
+    if not result:
+        return ""
+    lines = []
+    for item in result:
+        if item is None:
+            continue
+        text = ""
+        if isinstance(item, dict):
+            text = item.get("text") or item.get("rec_txt") or ""
+        elif isinstance(item, (list, tuple)):
+            if len(item) >= 2 and isinstance(item[1], str):
+                text = item[1]
+            elif item and isinstance(item[0], str):
+                text = item[0]
+        text = str(text).strip()
+        if text:
+            lines.append(text)
+    return "\n".join(lines)
+
+
 def load_ocr(model_name: str):
     """Return a callable image-path -> text. Heavy imports stay here."""
     from PIL import Image
 
     name = model_name.lower()
+    if name == "paddle":
+        try:
+            from rapidocr import RapidOCR
+        except ImportError:
+            raise SystemExit(
+                "paddle OCR needs rapidocr: pip install rapidocr onnxruntime"
+            )
+        engine = RapidOCR()
+
+        def ocr(path: str) -> str:
+            return texts_from_paddle(engine(path))
+
+        return ocr, PADDLE_MODEL
+
     if name == "trocr":
         from transformers import TrOCRProcessor, VisionEncoderDecoderModel
 
@@ -220,7 +267,7 @@ def load_ocr(model_name: str):
 
         return ocr, DONUT_MODEL
 
-    raise SystemExit("Unknown --model %s (use trocr or donut)" % model_name)
+    raise SystemExit("Unknown --model %s (use paddle, trocr or donut)" % model_name)
 
 
 def index_docs(solr_url: str, docs: list[dict]) -> None:
@@ -232,15 +279,16 @@ def index_docs(solr_url: str, docs: list[dict]) -> None:
 
 def main(argv=None) -> int:
     parser = argparse.ArgumentParser(
-        description="OCR a chunk file of images with TrOCR or Donut and post to Solr."
+        description="OCR a chunk file of images with Paddle/RapidOCR, TrOCR, or Donut and post to Solr."
     )
     parser.add_argument("-f", "--chunk-file", required=True, help="text file, one image path per line")
     parser.add_argument("-s", "--solr-url", required=True, help="Solr core URL, e.g. http://localhost:8983/solr/imagecat")
     parser.add_argument(
         "--model",
-        default="trocr",
-        choices=("trocr", "donut"),
-        help="trocr = printed/scene text (default); donut = document understanding",
+        default="paddle",
+        choices=("paddle", "trocr", "donut"),
+        help="paddle = PP-OCR detect-then-recognize (default; empty if no text); "
+        "trocr = printed line recognizer; donut = document understanding",
     )
     parser.add_argument("--commit-every", type=int, default=32, help="Solr batch size")
     parser.add_argument(

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 # Python half of the ImageCat pipeline. bin/imagecat-setup installs these
-# into $IMAGECAT_HOME/.venv. TrOCR/Donut pull torch + transformers on first
-# use; the HuggingFace model weights download then, not at pip time.
+# into $IMAGECAT_HOME/.venv. Paddle OCR is RapidOCR + onnxruntime (pip).
+# TrOCR/Donut pull torch + transformers on first use; the HuggingFace
+# model weights download then, not at pip time.
 
 pysolr>=3.9.0
 Pillow>=10.0.0
@@ -8,6 +9,9 @@ Pillow>=10.0.0
 transformers>=4.40.0,<5
 sentencepiece>=0.2.0
 torch>=2.2.0
+# --model paddle: PP-OCR ONNX via RapidOCR (Apache 2.0). Detect-then-recognize.
+rapidocr>=3.0
+onnxruntime>=1.17
 
 # ImageSpace API (FastAPI sidecar). CLIP extras are in
 # imagespace/requirements-embed.txt. IQR is Keras 3 on the Torch

--- a/solr/src/main/resources/imagecat/README.txt
+++ b/solr/src/main/resources/imagecat/README.txt
@@ -1,5 +1,7 @@
 imagecat core
 =============
 
-Solr home for OCR text extracted by imagecat-ocr.py (TrOCR or Donut).
-Document id is the original image path. Solr Cell / Tesseract are gone.
+Solr home for OCR text extracted by imagecat-ocr.py (Paddle/RapidOCR
+by default; TrOCR or Donut if chosen). Document id is the original
+image path. Solr Cell / Tesseract are gone. ocr_text uses text_ocr so
+URL overlays like emmejihad.wordpress.com are searchable as wordpress.

--- a/solr/src/main/resources/imagecat/conf/schema.xml
+++ b/solr/src/main/resources/imagecat/conf/schema.xml
@@ -17,9 +17,12 @@
 -->
 <!--
   OCR / image-content core. id is the original file path. ocr_text is what
-  TrOCR or Donut produced. Tika MIME/EXIF from imagecat-ocr.py lands on
-  content_type and the catch-all dynamicField (tiff_Make, Exif_IFD0_*, …).
-  sha1sum_s_md is filled by the OCR PGE and by sha1sum.py.
+  Paddle/RapidOCR, TrOCR, or Donut produced. Tika MIME/EXIF from
+  imagecat-ocr.py lands on content_type and the catch-all dynamicField
+  (tiff_Make, Exif_IFD0_*, …). sha1sum_s_md is filled by the OCR PGE
+  and by sha1sum.py. ocr_text uses text_ocr so a URL like
+  emmejihad.wordpress.com is searchable as wordpress, not only as the
+  whole host token StandardTokenizer would keep.
 -->
 <schema name="imagecat" version="1.6">
 
@@ -36,6 +39,31 @@
     </analyzer>
     <analyzer type="query">
       <tokenizer name="standard"/>
+      <filter name="stop" ignoreCase="true" words="stopwords.txt"/>
+      <filter name="synonymGraph" synonyms="synonyms.txt" ignoreCase="true" expand="true"/>
+      <filter name="lowercase"/>
+    </analyzer>
+  </fieldType>
+
+  <!-- OCR overlays are often URLs / watermarks. StandardTokenizer keeps
+       emmejihad.wordpress.com as one token, so q=wordpress misses.
+       Split on punctuation, keep the original token too. -->
+  <fieldType name="text_ocr" class="solr.TextField" positionIncrementGap="100">
+    <analyzer type="index">
+      <tokenizer name="standard"/>
+      <filter name="wordDelimiterGraph" generateWordParts="1" generateNumberParts="1"
+              catenateWords="0" catenateNumbers="0" catenateAll="0"
+              splitOnCaseChange="0" splitOnNumerics="0"
+              stemEnglishPossessive="0" preserveOriginal="1"/>
+      <filter name="stop" ignoreCase="true" words="stopwords.txt"/>
+      <filter name="lowercase"/>
+    </analyzer>
+    <analyzer type="query">
+      <tokenizer name="standard"/>
+      <filter name="wordDelimiterGraph" generateWordParts="1" generateNumberParts="1"
+              catenateWords="0" catenateNumbers="0" catenateAll="0"
+              splitOnCaseChange="0" splitOnNumerics="0"
+              stemEnglishPossessive="0" preserveOriginal="1"/>
       <filter name="stop" ignoreCase="true" words="stopwords.txt"/>
       <filter name="synonymGraph" synonyms="synonyms.txt" ignoreCase="true" expand="true"/>
       <filter name="lowercase"/>
@@ -59,7 +87,7 @@
   </fieldType>
 
   <field name="id" type="string" indexed="true" stored="true" required="true" multiValued="false"/>
-  <field name="ocr_text" type="text_general" indexed="true" stored="true" required="false" multiValued="false"/>
+  <field name="ocr_text" type="text_ocr" indexed="true" stored="true" required="false" multiValued="false"/>
   <field name="ocr_model_s" type="string" indexed="true" stored="true" required="false" multiValued="false"/>
   <field name="sha1sum_s_md" type="string" indexed="true" stored="true" required="false" multiValued="false"/>
   <field name="caption" type="text_general" indexed="true" stored="true" required="false" multiValued="false"/>

--- a/tests/test_pge_python.py
+++ b/tests/test_pge_python.py
@@ -75,6 +75,28 @@ class ChunkFileTests(unittest.TestCase):
         self.assertNotIn("<scalar name=\"DataProvider\">OODT</scalar>", text)
 
 
+class PaddleOcrResultTests(unittest.TestCase):
+    def test_empty_when_detector_finds_nothing(self):
+        self.assertEqual(ocr.texts_from_paddle(None), "")
+        self.assertEqual(ocr.texts_from_paddle((None, None)), "")
+        self.assertEqual(ocr.texts_from_paddle([]), "")
+        class Empty:
+            txts = ()
+        self.assertEqual(ocr.texts_from_paddle(Empty()), "")
+
+    def test_joins_rapidocr_txts(self):
+        class Out:
+            txts = ("HELLO", "WORLD")
+        self.assertEqual(ocr.texts_from_paddle(Out()), "HELLO\nWORLD")
+
+    def test_joins_legacy_box_text_score(self):
+        rows = [[[0, 0], [1, 0], [1, 1], [0, 1]], "CASHIER", 0.99]
+        self.assertEqual(ocr.texts_from_paddle([rows]), "CASHIER")
+
+    def test_paddle_is_a_model_choice(self):
+        self.assertEqual(ocr.PADDLE_MODEL, "rapidocr/pp-ocr")
+
+
 class TikaSolrMappingTests(unittest.TestCase):
     def test_content_type_field(self):
         self.assertEqual(ocr.solr_field_name("Content-Type"), "content_type")

--- a/workflow/src/main/resources/policy/tasks.xml
+++ b/workflow/src/main/resources/policy/tasks.xml
@@ -27,7 +27,7 @@
       <property name="PCS_ClientTransferServiceFactory" value="org.apache.oodt.cas.filemgr.datatransfer.InPlaceDataTransferFactory"/>
       <property name="PCS_ActionRepoFile" value="file:[CRAWLER_HOME]/policy/crawler-config.xml" envReplace="true"/>
       <property name="SolrUrl" value="http://localhost:8983/solr/imagecat"/>
-      <property name="OcrModel" value="trocr"/>
+      <property name="OcrModel" value="paddle"/>
     </configuration>
     <requiredMetFields/>
   </task>
@@ -78,7 +78,7 @@
       <property name="PCS_ClientTransferServiceFactory" value="org.apache.oodt.cas.filemgr.datatransfer.InPlaceDataTransferFactory"/>
       <property name="PCS_ActionRepoFile" value="file:[CRAWLER_HOME]/policy/crawler-config.xml" envReplace="true"/>
       <property name="SolrUrl" value="http://localhost:8983/solr/imagecat"/>
-      <property name="OcrModel" value="trocr"/>
+      <property name="OcrModel" value="paddle"/>
     </configuration>
     <requiredMetFields/>
   </task>


### PR DESCRIPTION
## What happens

`--model trocr` (microsoft/trocr-base-printed) is a **line** recognizer. Ingest feeds it the whole photograph. On CTCEU portraits with no letters it still emitted a receipt word: Pic 17 `CASHIER`, Pic 42 `RECEIPT`. Across 653 docs TrOCR never stored an empty `ocr_text`; the top strings were `0`, `:`, `@`, `TAX`, `CASHIER`.

`--model paddle` is PP-OCR via RapidOCR (Apache 2.0 ONNX, detect then recognize). No boxes → empty `ocr_text`. Same 653: **307 with text, 346 empty**. Pic 17/42 empty. Overlays that are actually there become searchable (`allah` hits the White House caption; `VICE NEWS`, `© AFP/Getty Images`, ICE camera timestamps).

Search still missed `wordpress` even when the analyst could see `emmejihad.wordpress.com` in OCR. `StandardTokenizer` keeps letter-dot-letter as one token. `ocr_text` now uses `text_ocr` (`WordDelimiterGraph`, preserve original) so `q=wordpress` hits. Live core reloaded and the 307 strings were XML-atomic re-posted (Tika kept). ImageSpace `wordpress` → 8 docs; `allah` still 1.

## Default

`OcrModel` in `tasks.xml` and `imagecat-ocr.py --model` default to `paddle`. TrOCR and Donut stay as `--model trocr` / `--model donut`. `bin/imagecat-setup` installs `rapidocr` + `onnxruntime`.

## Tests

`python3 tests/test_pge_python.py` — 11 run, 0 failures (empty RapidOCR output, `txts` join, legacy box/text/score).

Live CTCEU E2E on this stack finished ingest (fg/bg 653/653). Schema + paddle are what that run used.