### PR TITLE
Let a saved tray thumb be dropped without opening it

### DIFF
--- a/imagespace/web/src/App.vue
+++ b/imagespace/web/src/App.vue
@@ -3,9 +3,12 @@
     <aside class="tray">
       <h2>Saved</h2>
       <p v-if="!tray.length" class="empty">Save an image from the grid to pin it here.</p>
-      <button v-for="row in tray" :key="row.id" class="tray-item" :class="{ active: open && open.id === row.id }" @click="openDoc(row.id)">
-        <img :src="fileSrc(row.id, 180)" :alt="basename(row.id)" loading="lazy" decoding="async"/>
-      </button>
+      <div v-for="row in tray" :key="row.id" class="tray-item" :class="{ active: open && open.id === row.id }">
+        <button type="button" class="tray-thumb" :title="basename(row.id)" @click="openDoc(row.id)">
+          <img :src="fileSrc(row.id, 180)" :alt="basename(row.id)" loading="lazy" decoding="async"/>
+        </button>
+        <button type="button" class="tray-remove" title="Remove from tray" :aria-label="'Remove ' + basename(row.id) + ' from tray'" @click.stop="dropSaved(row)">×</button>
+      </div>
     </aside>
     <div class="main">
       <header class="mast">
@@ -123,7 +126,7 @@
 import { computed, nextTick, onMounted, ref } from 'vue'
 import { canSearchField, fieldEntries, fileSrc, getDoc, getHealth, refineIqr, scalar, search, similar, valueList } from './api.js'
 import { addFilter, filterLabel, isActiveFilter, looksLikeFieldQuery, removeFilter } from './filters.js'
-import { inTray, loadTray, saveTray, toggleTray } from './tray.js'
+import { inTray, loadTray, removeFromTray, saveTray, toggleTray } from './tray.js'
 
 export default {
   name: 'App',
@@ -349,6 +352,11 @@ export default {
       saveTray(tray.value)
     }
 
+    function dropSaved(row) {
+      tray.value = removeFromTray(tray.value, row && row.id)
+      saveTray(tray.value)
+    }
+
     async function runSearch(start) {
       loading.value = true
       error.value = ''
@@ -499,7 +507,7 @@ export default {
     return {
       q, filters, addingFilter, newField, newValue, newFieldEl, fieldHints, docs, numFound, loading, error, open, tray, health, similarTo, similarSpace, iqrPos, iqrNeg, iqrActive, refining,
       statusLine, canSimilar, canIqr, canFgbg, canMeta, canFg, canBg, fgTitle, bgTitle, similarLabel, isPos, isNeg, markPos, markNeg, runIqr, clearIqr,
-      basename, scoreLine, formatVal, formatOne, searchField, dropFilter, startAddFilter, cancelAddFilter, submitNewFilter, filterLabel, isActiveFilter, canSearchField, valueList, saved, toggle, runSearch, onSearchBox, loadMore, runSimilar, clearSimilar, openDoc, fileSrc, fieldEntries, scalar
+      basename, scoreLine, formatVal, formatOne, searchField, dropFilter, startAddFilter, cancelAddFilter, submitNewFilter, filterLabel, isActiveFilter, canSearchField, valueList, saved, toggle, dropSaved, runSearch, onSearchBox, loadMore, runSimilar, clearSimilar, openDoc, fileSrc, fieldEntries, scalar
     }
   }
 }

--- a/imagespace/web/src/style.css
+++ b/imagespace/web/src/style.css
@@ -49,17 +49,49 @@ button:disabled { opacity: 0.45; cursor: not-allowed; }
 .tray h2 { font-size: 0.82rem; margin: 0 0 0.5rem; letter-spacing: 0.04em; text-transform: uppercase; color: var(--muted); }
 .tray .empty { font-size: 0.8rem; color: var(--muted); }
 .tray-item {
+  position: relative;
   display: block;
   width: 100%;
   margin: 0 0 0.45rem;
-  padding: 0;
-  background: none;
   border: 1px solid var(--line);
   border-radius: 3px;
   overflow: hidden;
 }
+.tray-thumb {
+  display: block;
+  width: 100%;
+  margin: 0;
+  padding: 0;
+  background: none;
+  border: 0;
+  border-radius: 0;
+  color: inherit;
+}
+.tray-thumb:hover:not(:disabled) { background: none; }
 .tray-item img { display: block; width: 100%; height: 5.5rem; object-fit: cover; }
 .tray-item.active { outline: 2px solid var(--copper); }
+.tray-remove {
+  position: absolute;
+  top: 0.2rem;
+  right: 0.2rem;
+  z-index: 1;
+  width: 1.25rem;
+  height: 1.25rem;
+  padding: 0;
+  line-height: 1.15rem;
+  font-size: 0.95rem;
+  font-weight: 700;
+  color: #fff8f3;
+  background: rgba(28, 25, 23, 0.72);
+  border: 0;
+  border-radius: 2px;
+}
+.tray-remove:hover:not(:disabled) { background: var(--copper-dark); }
+@media (hover: hover) and (pointer: fine) {
+  .tray-remove { opacity: 0; }
+  .tray-item:hover .tray-remove,
+  .tray-item:focus-within .tray-remove { opacity: 1; }
+}
 
 .main { display: flex; flex-direction: column; min-width: 0; }
 .mast {

--- a/imagespace/web/src/tray.js
+++ b/imagespace/web/src/tray.js
@@ -17,12 +17,16 @@ export function inTray(rows, id) {
   return rows.some((row) => row.id === id)
 }
 
+export function removeFromTray(rows, id) {
+  return rows.filter((row) => row.id !== id)
+}
+
 export function toggleTray(rows, doc) {
   if (!doc || !doc.id) {
     return rows
   }
   if (inTray(rows, doc.id)) {
-    return rows.filter((row) => row.id !== doc.id)
+    return removeFromTray(rows, doc.id)
   }
   const next = rows.concat([{ id: doc.id, content_type: doc.content_type }])
   return next

--- a/imagespace/web/src/tray.test.js
+++ b/imagespace/web/src/tray.test.js
@@ -1,0 +1,16 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { inTray, removeFromTray, toggleTray } from './tray.js'
+
+test('x on a tray thumb drops that pin and leaves the rest', () => {
+  const a = { id: '/data/a.jpg', content_type: 'image/jpeg' }
+  const b = { id: '/data/b.jpg', content_type: 'image/jpeg' }
+  let rows = []
+  rows = toggleTray(rows, a)
+  rows = toggleTray(rows, b)
+  assert.equal(rows.length, 2)
+  rows = removeFromTray(rows, a.id)
+  assert.equal(inTray(rows, a.id), false)
+  assert.equal(inTray(rows, b.id), true)
+  assert.deepEqual(rows, [b])
+})


### PR DESCRIPTION
## Why

Once an image is in Saved, the only way to unpin it was to click the thumb (which opens the detail pane) and then **Remove from tray**. That is extra navigation for a pin list.

## What

Each tray thumb is no longer one big button. The image still opens the doc. A small × in the upper-right removes that pin and leaves the rest.

- Pointer + hover: × appears on hover or keyboard focus-within.
- Touch: × stays visible (`hover: hover` / `pointer: fine` media query).
- Click does not open the image (`stop` on the remove button).
- Detail pane stays put if that image is already open; the Save button flips back to **Save to tray**.

## Tests

`npm test` in `imagespace/web` — 4 run, 0 failures (new: *x on a tray thumb drops that pin and leaves the rest*).