### PR TITLE
Refresh README, roadmap, and Tomcat home for paddle OCR

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,10 +21,11 @@ its own process (not a Tomcat war) with two cores: `imagecat` (OCR text) and
 [ImageSpace](imagespace/README.md) is the analyst desktop in this same tarball:
 search OCR and Tika fields, browse the image grid, CLIP similar, foreground /
 background similar (U2-Net / rembg), and IQR (a tiny Keras head fitted at
-Refine time on CLIP vectors). `bin/oodt start` brings it up on port 8090
-the way it starts Solr — FastAPI, not a WAR. CLIP / fg / bg indexes live
-under `$IMAGECAT_HOME/data/imagespace/`. This is new work inspired by
-NASA JPL's efforts on the DARPA MEMEX program.
+Refine time on CLIP vectors). Saved thumbs sit in a tray; hover (or tap) the
+× to drop one. `bin/oodt start` brings it up on port 8090 the way it starts
+Solr — FastAPI, not a WAR. CLIP / fg / bg indexes live under
+`$IMAGECAT_HOME/data/imagespace/`. This is new work inspired by NASA JPL's
+efforts on the DARPA MEMEX program.
 
 See [docs/WHAT-IS-IN.md](docs/WHAT-IS-IN.md) for keep / throw / replace
 and [docs/roadmap.md](docs/roadmap.md) for where we are and what is next.
@@ -57,6 +58,8 @@ The IngestInPlace PGE calls `imagecat-ocr.py` over each chunk file.
 means empty `ocr_text`, not a hallucinated receipt word.
 `--model trocr` is a printed line recognizer;
 `--model donut` is document understanding and also fills `caption`.
+`ocr_text` is Solr field type `text_ocr` (WordDelimiter, preserve original)
+so a URL overlay like `emmejihad.wordpress.com` is searchable as `wordpress`.
 Tika runs on each image in that same script (MIME, EXIF, IPTC) so the
 `imagecat` Solr core has the metadata Solr Cell used to attach. Tesseract
 and Solr Cell are gone. The old `solrcell_ingest` name remains as a shim
@@ -76,10 +79,11 @@ After OCR, the same ingest workflow scores Tika metadata Jaccard
 (`urn:memex:IndexMetadataJaccard`), then CLIP/FAISS
 (`urn:memex:IndexImageSpace`) and foreground/background CLIP
 (`urn:memex:IndexImageSpaceFgBg`). The UI at
-`http://127.0.0.1:8090/` searches Solr, shows the pictures, and
-runs Similar / FG / BG / Keys / Vals against those indexes. IQR is not a pretrained
-model: mark tiles + / − and Refine fits a small Keras head (Torch
-backend) on the CLIP vectors you already have.
+`http://127.0.0.1:8090/` searches Solr (`ocr_text`, `caption`, copy-field
+`text`), shows the pictures, and runs Similar / FG / BG / Keys / Vals
+against those indexes. IQR is not a pretrained model: mark tiles + / −
+and Refine fits a small Keras head (Torch backend) on the CLIP vectors
+you already have.
 
 `bin/imagecat-setup` installs Keras with the rest of the Python env
 and builds the Vue UI. Vite on 5173 is optional for UI development.

--- a/docs/WHAT-IS-IN.md
+++ b/docs/WHAT-IS-IN.md
@@ -44,8 +44,9 @@ into Solr, File Manager catalogs the files. The stack under it is new.
 
 ## Replace later
 
-- SMQTK / FLANN / Caffe (already replaced in-tree by CLIP + rembg + Keras)
 - Columbia / Georgetown / weapons / VideoSpace (not v1)
 
+SMQTK / FLANN / Caffe, Girder ImageSpace, and the NASA `image_space` tree
+are gone: CLIP + rembg + Keras IQR in this tarball is the replacement.
 SCE domain discovery stays public for Sparkler. Sparkler itself lives at
 [gitlab.com/sparkler-crawl-environment/sparkler](https://gitlab.com/sparkler-crawl-environment/sparkler).

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -4,7 +4,8 @@ ImageCat is the ingest pipeline. ImageSpace is the analyst desktop (now
 in this tarball). OPSUI (Mnemosyne) is how we watch the jobs.
 
 The product path is in. Wiki Installation / How to Run match `bin/imagecat-setup`
-plus `bin/oodt start` plus ImageSpace on **8090**.
+plus `bin/oodt start` plus ImageSpace on **8090**. Paddle/RapidOCR is the
+default OCR. ImageSpace lives in this tarball, not a second GitHub repo.
 
 ## Where we started
 
@@ -27,23 +28,17 @@ local `IMAGE_SPACE_HOME`. ImageSpace was a second repo.
 | Keras IQR in the distro; README ImageSpace section | ImageCat #56 |
 | MEMEX credit (no second-tree pointer) | ImageCat #57 |
 | PGE Peek, progress bar, W1 `PGE EXEC` stamp, wall clock | Mnemosyne #262, #265, #270, #256 |
+| Tika metadata Jaccard + Keys/Vals | ImageCat #61, #62 |
+| Paddle/RapidOCR default; `text_ocr` URL split | ImageCat #63 |
+| Tray × to drop a saved thumb | ImageCat #64 |
 | Wiki Installation / How to Run / Interacting | [imagecat wiki](https://github.com/chrismattmann/imagecat/wiki) |
-
-## Live (this box)
-
-- Solr `imagecat` **653** (CTCEU + ice JPGs; PDFs skipped)
-- CLIP + fg/bg + IQR **on** at http://127.0.0.1:8090/
-- OPSUI http://localhost:8080/opsui/
-- W1 `ThreadPoolWorkflowEngineFactory` (do not switch to W2)
-- DRAT **9000/9001**; ImageCat FM/WM **9100/9101**
-- Mnemosyne #270 is on the live WM (`PGE EXEC` while a PGE runs)
 
 ## Next
 
-1. ~~Wiki / How to Run~~ **done**
-2. **One clean unpack** — rebuild the tarball and start from it so live is not a pile of overlays
-3. **Leave settled-condition unwired** until IngestInPlace is fanned out across chunks; sequential CLIP already waits. A fan-out would want a Solr settle, not FM `ChunkList`
-4. **Archive** `chrismattmann/image_space` on GitHub when the README pointer should be official
+1. **One clean unpack** — rebuild the tarball and start from it so a live tree is not a pile of overlays
+2. **Leave settled-condition unwired** until IngestInPlace is fanned out across chunks; sequential CLIP already waits. A fan-out would want a Solr settle, not FM `ChunkList`
+
+~~Archive `chrismattmann/image_space`~~ **done** (remote deleted; product is `imagespace/` in this repo).
 
 Not next unless asked: W2, DRAT-in-ImageCat, wiring Mnemosyne #267.
 
@@ -51,3 +46,4 @@ Not next unless asked: W2, DRAT-in-ImageCat, wiring Mnemosyne #267.
 
 - **DRAT `.progress`** — done separately (Claude)
 - **Mnemosyne #267 `ProductCountSettledCondition`** — merged, not wired. Pre-condition that waits until an FM product type stops growing. ImageCat’s CLIP catalog is Solr `imagecat`, and today’s workflow is sequential, so this stays off until we fan-out ingest
+- **W1 only** — `ThreadPoolWorkflowEngineFactory`. Do not switch to W2. If another stack already owns 9000/9001, set `FILEMGR_PORT` / `WORKFLOW_PORT` / `RESMGR_PORT` in `bin/setenv.sh` (git default stays 9000).

--- a/imagespace/README.md
+++ b/imagespace/README.md
@@ -1,8 +1,10 @@
 # ImageSpace (inside ImageCat)
 
-Analyst desktop for this RADiX stack: Solr search, CLIP similar, fg/bg,
-metadata Jaccard (Keys / Vals), IQR. Packed into the ImageCat tarball
-and started by `bin/oodt start` (FastAPI on port 8090, same idea as Solr).
+Analyst desktop for this RADiX stack: Solr search (`ocr_text` / `text_ocr`,
+caption, Tika), CLIP similar, fg/bg, metadata Jaccard (Keys / Vals), IQR,
+and a tray of saved thumbs (hover × to drop). Packed into the ImageCat
+tarball and started by `bin/oodt start` (FastAPI on port 8090, same idea
+as Solr).
 
 CLIP / fg / bg files live under `$OODT_HOME/data/imagespace/`, not in git.
 

--- a/imagespace/docs/WHAT-IS-IN.md
+++ b/imagespace/docs/WHAT-IS-IN.md
@@ -9,8 +9,9 @@ it and shows the pictures.
 - Solr `imagecat` as the catalog (`id`, `ocr_text`, Tika EXIF, `sha1sum_s_md`)
 - Search box = OCR / metadata; `*` = browse
 - Image grid
-- Detective tray of saved images
+- Detective tray of saved images (hover / tap × to drop)
 - Details: full Tika record + thumbnail; click a field value to search Solr for it
+- `ocr_text` via ImageCat `text_ocr` so URL-like OCR is searchable as words
 - Images on disk at the Solr `id` path
 
 ## Throw out

--- a/webapps/home/index.html
+++ b/webapps/home/index.html
@@ -5,7 +5,7 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <!-- The above 3 meta tags *must* come first in the head; any other head content must come *after* these tags -->
-    <title>JPL/Kitware/Continuum - ImageCat</title>
+    <title>ImageCat</title>
 
     <!-- Bootstrap -->
     <link href="css/bootstrap.min.css" rel="stylesheet">
@@ -48,11 +48,11 @@
     <div class="container center">
        <div class="starter-template">
 	<div class="center"><img src="img/ImageCatLogo.png" alt="Image Cat" width="600" height="300"/></div>
-        <p class="lead">ImageCat is a rich index in <a href="http://lucene.apache.org/solr/">Apache Solr</a> of extracted image OCR and metadata features using the <a href="http://tika.apache.org/">Apache Tika</a> library. ImageCat uses <a href="http://oodt.apache.org/">Apache OODT</a> as a mechanism for loading the Apache Solr catalog, via Apache Tika. A user provides an image list text file with 10s of millions of images, and ImageCat uses OODT to map reduce through the file, and ingest the images and extract the metadata via Tika and Solr. <a href="http://github.com/memex-explorer/image_space">Image Space</a>, an application that leverages ImageCat, allows a user to browse and search the rich Solr catalog built by Tika and OODT. You can access the OODT and Solr and Image Space apps below. The data is currently loaded with the full Roxyimages dataset from <a href="http://www.darpa.mil/newsevents/releases/2014/02/09.aspx">DARPA Memex</a>.
+        <p class="lead">ImageCat is a <a href="https://cwiki.apache.org/confluence/display/OODT/RADiX+Powered+By+OODT">RADiX</a> overlay on <a href="https://github.com/chrismattmann/mnemosyne">Mnemosyne</a> 1.11.0. It ingests images in place, extracts MIME/EXIF with <a href="https://tika.apache.org/">Apache Tika</a>, OCRs them with Paddle/RapidOCR into <a href="https://solr.apache.org/">Apache Solr</a> 10, and serves the catalog through <a href="http://127.0.0.1:8090/">ImageSpace</a> (search, CLIP similar, fg/bg, IQR). OPSUI at <a href="/opsui/">/opsui/</a> is the job console. This ImageSpace is new work inspired by NASA JPL's efforts on the DARPA MEMEX program.
 	</p>
 
       <div class="container center">
-           <p>You can find the source code for ImageCat on <a href="http://github.com/chrismattmann/imagecat">Github</a> and on the <a href="http://www.darpa.mil/opencatalog/MEMEX.html">DARPA Open Catalog for Memex</a>.
+           <p>Source: <a href="https://github.com/chrismattmann/imagecat">github.com/chrismattmann/imagecat</a>. Wiki: <a href="https://github.com/chrismattmann/imagecat/wiki">Installation and How to Run</a>.
       </div>
 </div>
 </div>
@@ -63,10 +63,10 @@
        <div class="starter-template">
     <div class="row">
         <div class="col-md-6"><p><h4>ImageCat Processing Pipeline</h4><a href="/opsui/" border="0"><img alt="Apache OODT OPSUI" src="img/oodt.png" width="240" height="80"/></a></p></div>
-        <div class="col-md-6"><p><h4>ImageCat Search Index</h4><a href="/solr/" border="0"><img alt="Apache Solr and Tika" src="img/solr.png" width="210" height="60"/></a></p></div>
+        <div class="col-md-6"><p><h4>ImageCat Search Index</h4><a href="http://localhost:8983/solr/imagecat" border="0"><img alt="Apache Solr and Tika" src="img/solr.png" width="210" height="60"/></a></p></div>
     </div>
     <div class="row">
-        <div class="col-md-12"><p><h4>Image Space</h4><a href="/imagespace/" border="0"><img alt="Image Space" src="img/imagespace.jpg" width="240" height="80"/></a></p></div>
+        <div class="col-md-12"><p><h4>ImageSpace</h4><a href="http://127.0.0.1:8090/" border="0"><img alt="ImageSpace" src="img/imagespace.jpg" width="240" height="80"/></a></p></div>
     </div>
 </div>
 </div>
@@ -78,7 +78,7 @@
             <div class="row">
                 <div class="col-lg-14">
                     <h1>About ImageCat</h1>
-                     <p class="lead">ImageCat is an application built by <a href="http://www.jpl.nasa.gov">NASA Jet Propulsion Laboratory</a>, <a href="http://www.kitware.com">Kitware, Inc.</a>, and <a href="http://continuum.io">Continuum Analytics, Inc</a>
+                     <p class="lead">ImageCat is a RADiX overlay on Mnemosyne. The ImageSpace desktop in this tarball is inspired by work NASA JPL, Kitware, and Continuum Analytics did on the DARPA MEMEX program.
                      </p>
                 </div>
             </div>


### PR DESCRIPTION
Wiki is already updated on `imagecat.wiki` (paddle default, Jaccard in the ingest flow, `text_ocr`, tray ×, no CHIPOTLE ports). This PR is the in-repo copy of that.

- README: tray ×, `text_ocr` URL split, ImageSpace search fields
- `docs/roadmap.md`: #61–#64 on the slice table; `image_space` archive item done; drop the live-box port dump
- `docs/WHAT-IS-IN.md`: SMQTK / Girder / NASA `image_space` are gone, not “replace later”
- Tomcat `webapps/home`: Mnemosyne + ImageSpace on 8090, not Girder `/imagespace/` and Roxyimages
- GitHub repo description now leads with Paddle/RapidOCR; homepage is the wiki

No code changes.