### PR TITLE
Rename workflow IDs from urn:memex: to urn:imagecat:

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,9 +76,9 @@ ImageSpace
 ----------
 
 After OCR, the same ingest workflow scores Tika metadata Jaccard
-(`urn:memex:IndexMetadataJaccard`), then CLIP/FAISS
-(`urn:memex:IndexImageSpace`) and foreground/background CLIP
-(`urn:memex:IndexImageSpaceFgBg`). The UI at
+(`urn:imagecat:IndexMetadataJaccard`), then CLIP/FAISS
+(`urn:imagecat:IndexImageSpace`) and foreground/background CLIP
+(`urn:imagecat:IndexImageSpaceFgBg`). The UI at
 `http://127.0.0.1:8090/` searches Solr (`ocr_text`, `caption`, copy-field
 `text`), shows the pictures, and runs Similar / FG / BG / Keys / Vals
 against those indexes. IQR is not a pretrained model: mark tiles + / −

--- a/crawler/pom.xml
+++ b/crawler/pom.xml
@@ -21,7 +21,7 @@
 
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <groupId>gov.darpa.memex.imageCatalog</groupId>
+    <groupId>ai.mattmann.imagecat</groupId>
     <artifactId>oodt</artifactId>
     <version>0.1</version>
     <relativePath>../pom.xml</relativePath>
@@ -55,7 +55,7 @@
 
   <dependencies>
     <dependency>
-      <groupId>gov.darpa.memex.imageCatalog</groupId>
+      <groupId>ai.mattmann.imagecat</groupId>
       <artifactId>oodt-extensions</artifactId>
       <version>${project.parent.version}</version>
       <type>jar</type>

--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -21,7 +21,7 @@
    
    <modelVersion>4.0.0</modelVersion>
    <parent>
-      <groupId>gov.darpa.memex.imageCatalog</groupId>
+      <groupId>ai.mattmann.imagecat</groupId>
       <artifactId>oodt</artifactId>
       <version>0.1</version>
       <relativePath>../pom.xml</relativePath>
@@ -35,75 +35,75 @@
    </properties>
          <dependencies>
             <dependency>
-               <groupId>gov.darpa.memex.imageCatalog</groupId>
+               <groupId>ai.mattmann.imagecat</groupId>
                <artifactId>oodt-filemgr</artifactId>
                <version>${project.parent.version}</version>
                <type>tar.gz</type>
                <classifier>bin</classifier>
             </dependency>
             <dependency>
-               <groupId>gov.darpa.memex.imageCatalog</groupId>
+               <groupId>ai.mattmann.imagecat</groupId>
                <artifactId>oodt-crawler</artifactId>
                <version>${project.parent.version}</version>
                <type>tar.gz</type>
                <classifier>bin</classifier>
             </dependency>
             <dependency>
-               <groupId>gov.darpa.memex.imageCatalog</groupId>
+               <groupId>ai.mattmann.imagecat</groupId>
                <artifactId>oodt-workflow</artifactId>
                <version>${project.parent.version}</version>
                <type>tar.gz</type>
                <classifier>bin</classifier>
             </dependency>
             <dependency>
-               <groupId>gov.darpa.memex.imageCatalog</groupId>
+               <groupId>ai.mattmann.imagecat</groupId>
                <artifactId>oodt-pge</artifactId>
                <version>${project.parent.version}</version>
                <type>tar.gz</type>
                <classifier>bin</classifier>
             </dependency>
             <dependency>
-               <groupId>gov.darpa.memex.imageCatalog</groupId>
+               <groupId>ai.mattmann.imagecat</groupId>
                <artifactId>oodt-pcs</artifactId>
                <version>${project.parent.version}</version>
                <type>tar.gz</type>
                <classifier>bin</classifier>
             </dependency>
             <dependency>
-               <groupId>gov.darpa.memex.imageCatalog</groupId>
+               <groupId>ai.mattmann.imagecat</groupId>
                <artifactId>oodt-resmgr</artifactId>
                <version>${project.parent.version}</version>
                <type>tar.gz</type>
                <classifier>bin</classifier>
             </dependency>
             <dependency>
-               <groupId>gov.darpa.memex.imageCatalog</groupId>
+               <groupId>ai.mattmann.imagecat</groupId>
                <artifactId>oodt-extensions</artifactId>
                <version>${project.parent.version}</version>
                <type>tar.gz</type>
                <classifier>bin</classifier>
             </dependency>
             <dependency>
-               <groupId>gov.darpa.memex.imageCatalog</groupId>
+               <groupId>ai.mattmann.imagecat</groupId>
                <artifactId>oodt-solr</artifactId>
                <version>${project.parent.version}</version>
                <type>tar.gz</type>
                <classifier>bin</classifier>
             </dependency>
             <dependency>
-               <groupId>gov.darpa.memex.imageCatalog</groupId>
+               <groupId>ai.mattmann.imagecat</groupId>
                <artifactId>oodt-opsui</artifactId>
                <version>${project.parent.version}</version>
                <type>war</type>
             </dependency>
             <dependency>
-               <groupId>gov.darpa.memex.imageCatalog</groupId>
+               <groupId>ai.mattmann.imagecat</groupId>
                <artifactId>oodt-pcs-services</artifactId>
                <version>${project.parent.version}</version>
                <type>war</type>
             </dependency>
             <dependency>
-               <groupId>gov.darpa.memex.imageCatalog</groupId>
+               <groupId>ai.mattmann.imagecat</groupId>
                <artifactId>oodt-fmprod</artifactId>
                <version>${project.parent.version}</version>
                <type>war</type>
@@ -133,21 +133,21 @@
                                  <outputDirectory>${project.build.directory}/</outputDirectory>
                               </artifactItem>
                               <artifactItem>
-                                 <groupId>gov.darpa.memex.imageCatalog</groupId>
+                                 <groupId>ai.mattmann.imagecat</groupId>
                                  <artifactId>${project.parent.artifactId}-opsui</artifactId>
                                  <type>war</type>
                                  <overWrite>false</overWrite>
                                  <outputDirectory>${project.build.directory}/apache-tomcat-${tomcat.version}/webapps/opsui</outputDirectory>
                               </artifactItem>
                               <artifactItem>
-                                 <groupId>gov.darpa.memex.imageCatalog</groupId>
+                                 <groupId>ai.mattmann.imagecat</groupId>
                                  <artifactId>${project.parent.artifactId}-pcs-services</artifactId>
                                  <type>war</type>
                                  <overWrite>false</overWrite>
                                  <outputDirectory>${project.build.directory}/apache-tomcat-${tomcat.version}/webapps/pcs</outputDirectory>
                               </artifactItem>
                               <artifactItem>
-                                 <groupId>gov.darpa.memex.imageCatalog</groupId>
+                                 <groupId>ai.mattmann.imagecat</groupId>
                                  <artifactId>${project.parent.artifactId}-fmprod</artifactId>
                                  <type>war</type>
                                  <overWrite>false</overWrite>

--- a/distribution/src/main/resources/bin/check_failed
+++ b/distribution/src/main/resources/bin/check_failed
@@ -2,10 +2,10 @@
 
 if [ "$#" -eq 1 ]; then
     pushd $OODT_HOME/workflow/bin
-    ./wmgr-client --url $WORKFLOW_URL --operation --dynWorkflow  --taskIds urn:memex:CheckFailedTask --metaData --key ChunkStart $1
+    ./wmgr-client --url $WORKFLOW_URL --operation --dynWorkflow  --taskIds urn:imagecat:CheckFailedTask --metaData --key ChunkStart $1
     popd
 else
     pushd $OODT_HOME/workflow/bin
-    ./wmgr-client --url $WORKFLOW_URL --operation --dynWorkflow  --taskIds urn:memex:CheckFailedTask
+    ./wmgr-client --url $WORKFLOW_URL --operation --dynWorkflow  --taskIds urn:imagecat:CheckFailedTask
     popd
 fi

--- a/distribution/src/main/resources/bin/chunker
+++ b/distribution/src/main/resources/bin/chunker
@@ -21,4 +21,4 @@ else
 fi
 
 cd $OODT_HOME/workflow/bin
-./wmgr-client --url $WORKFLOW_URL --operation --dynWorkflow  --taskIds urn:memex:Chunker --metaData --key ImageListFile $LIST_FILE
+./wmgr-client --url $WORKFLOW_URL --operation --dynWorkflow  --taskIds urn:imagecat:Chunker --metaData --key ImageListFile $LIST_FILE

--- a/docs/WHAT-IS-IN.md
+++ b/docs/WHAT-IS-IN.md
@@ -10,7 +10,7 @@ into Solr, File Manager catalogs the files. The stack under it is new.
 - Chunker → Ingest-in-place → Solr
 - File Manager catalog (Solr core `oodt-fm`)
 - Tika MIME / EXIF on the Solr `imagecat` core (`imagecat-ocr.py`), the same place Solr Cell used to put it. File Manager catalogs ChunkList path files, not the images.
-- FLAG: after IngestInPlace, metadata Jaccard, ImageSpace CLIP/FAISS, and fg/bg are incremented (`urn:memex:IndexMetadataJaccard`, `urn:memex:IndexImageSpace`, `urn:memex:IndexImageSpaceFgBg`).
+- FLAG: after IngestInPlace, metadata Jaccard, ImageSpace CLIP/FAISS, and fg/bg are incremented (`urn:imagecat:IndexMetadataJaccard`, `urn:imagecat:IndexImageSpace`, `urn:imagecat:IndexImageSpaceFgBg`).
 - Vue OPSUI overlay of `ai.mattmann.mnemosyne:pcs-opsui`
 - ImageSpace analyst UI in this repo (`imagespace/`), started by `bin/oodt start` on port 8090. Indexes under `$OODT_HOME/data/imagespace/`. Inspired by NASA JPL's work on the DARPA MEMEX program.
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -31,7 +31,7 @@ local `IMAGE_SPACE_HOME`. ImageSpace was a second repo.
 | Tika metadata Jaccard + Keys/Vals | ImageCat #61, #62 |
 | Paddle/RapidOCR default; `text_ocr` URL split | ImageCat #63 |
 | Tray × to drop a saved thumb | ImageCat #64 |
-| Workflow/FM IDs `urn:imagecat:` (was `urn:memex:`) | this PR |
+| Workflow/FM IDs `urn:imagecat:` (was `urn:memex:`) | ImageCat #67 |
 | Wiki Installation / How to Run / Interacting | [imagecat wiki](https://github.com/chrismattmann/imagecat/wiki) |
 
 ## Next

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -31,6 +31,7 @@ local `IMAGE_SPACE_HOME`. ImageSpace was a second repo.
 | Tika metadata Jaccard + Keys/Vals | ImageCat #61, #62 |
 | Paddle/RapidOCR default; `text_ocr` URL split | ImageCat #63 |
 | Tray × to drop a saved thumb | ImageCat #64 |
+| Workflow/FM IDs `urn:imagecat:` (was `urn:memex:`) | this PR |
 | Wiki Installation / How to Run / Interacting | [imagecat wiki](https://github.com/chrismattmann/imagecat/wiki) |
 
 ## Next

--- a/extensions/pom.xml
+++ b/extensions/pom.xml
@@ -21,7 +21,7 @@
 
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <groupId>gov.darpa.memex.imageCatalog</groupId>
+    <groupId>ai.mattmann.imagecat</groupId>
     <artifactId>oodt</artifactId>
     <version>0.1</version>
     <relativePath>../pom.xml</relativePath>

--- a/filemgr/pom.xml
+++ b/filemgr/pom.xml
@@ -21,7 +21,7 @@
    
    <modelVersion>4.0.0</modelVersion>
    <parent>
-      <groupId>gov.darpa.memex.imageCatalog</groupId>
+      <groupId>ai.mattmann.imagecat</groupId>
       <artifactId>oodt</artifactId>
       <version>0.1</version>
       <relativePath>../pom.xml</relativePath>
@@ -89,7 +89,7 @@
    </profiles>
    <dependencies>
       <dependency>
-         <groupId>gov.darpa.memex.imageCatalog</groupId>
+         <groupId>ai.mattmann.imagecat</groupId>
          <artifactId>oodt-extensions</artifactId>
          <version>${project.parent.version}</version>
          <type>jar</type>

--- a/filemgr/src/main/resources/policy/imagecat/elements.xml
+++ b/filemgr/src/main/resources/policy/imagecat/elements.xml
@@ -16,7 +16,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 <cas:elements xmlns:cas="http://oodt.jpl.nasa.gov/1.0/cas">
-<element id="urn:memex:ChunkNum" name="ChunkNum">
+<element id="urn:imagecat:ChunkNum" name="ChunkNum">
    <dcElement/>
    <description>The subset of the original IST image catalog of file paths to process.</description>
 </element>

--- a/filemgr/src/main/resources/policy/imagecat/product-type-element-map.xml
+++ b/filemgr/src/main/resources/policy/imagecat/product-type-element-map.xml
@@ -21,7 +21,7 @@ of elements between the types
 -->
 
   <type id="urn:oodt:ChunkList" parent="urn:oodt:TraceableFile">
-    <element id="urn:memex:ChunkNum"/>
+    <element id="urn:imagecat:ChunkNum"/>
   </type>
 
 </cas:producttypemap>

--- a/imagespace/README.md
+++ b/imagespace/README.md
@@ -15,6 +15,6 @@ bin/oodt start        # includes ImageSpace
 ```
 
 Vite on 5173 is optional for UI development (`cd imagespace/web && npm run dev`).
-The ingest PGEs (`urn:memex:IndexMetadataJaccard`, `IndexImageSpace`,
+The ingest PGEs (`urn:imagecat:IndexMetadataJaccard`, `IndexImageSpace`,
 `IndexImageSpaceFgBg`) use `IMAGE_SPACE_HOME=$OODT_HOME/imagespace`
 from `bin/setenv.sh`.

--- a/imagespace/docs/IMAGECAT-HOOK.md
+++ b/imagespace/docs/IMAGECAT-HOOK.md
@@ -2,12 +2,12 @@
 
 After IngestInPlace writes OCR/Tika into Solr `imagecat`, ImageCat runs:
 
-1. `urn:memex:IndexMetadataJaccard` (`pge/bin/index-metadata-jaccard/index-metadata-jaccard.sh`)
+1. `urn:imagecat:IndexMetadataJaccard` (`pge/bin/index-metadata-jaccard/index-metadata-jaccard.sh`)
    — `python -m server.meta` (golden-set Jaccard on Tika keys/values, POST
    `jaccard_keys_f` / `jaccard_vals_f`, then `/api/meta/reload`)
-2. `urn:memex:IndexImageSpace` (`pge/bin/index-imagespace/index-imagespace.sh`)
+2. `urn:imagecat:IndexImageSpace` (`pge/bin/index-imagespace/index-imagespace.sh`)
    — `python -m server.embed --incremental`
-3. `urn:memex:IndexImageSpaceFgBg` (`pge/bin/index-imagespace-fgbg/index-imagespace-fgbg.sh`)
+3. `urn:imagecat:IndexImageSpaceFgBg` (`pge/bin/index-imagespace-fgbg/index-imagespace-fgbg.sh`)
    — `python -m server.embed_fgbg --incremental`
 
 `bin/setenv.sh` sets `IMAGE_SPACE_HOME=$OODT_HOME/imagespace`. Optional

--- a/pcs/pom.xml
+++ b/pcs/pom.xml
@@ -21,7 +21,7 @@
 
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <groupId>gov.darpa.memex.imageCatalog</groupId>
+    <groupId>ai.mattmann.imagecat</groupId>
     <artifactId>oodt</artifactId>
     <version>0.1</version>
     <relativePath>../pom.xml</relativePath>
@@ -56,7 +56,7 @@
 
   <dependencies>
     <dependency>
-      <groupId>gov.darpa.memex.imageCatalog</groupId>
+      <groupId>ai.mattmann.imagecat</groupId>
       <artifactId>oodt-extensions</artifactId>
       <version>${project.parent.version}</version>
       <type>jar</type>

--- a/pge/pom.xml
+++ b/pge/pom.xml
@@ -21,7 +21,7 @@
 
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <groupId>gov.darpa.memex.imageCatalog</groupId>
+    <groupId>ai.mattmann.imagecat</groupId>
     <artifactId>oodt</artifactId>
     <version>0.1</version>
     <relativePath>../pom.xml</relativePath>
@@ -55,7 +55,7 @@
  
   <dependencies>
     <dependency>
-      <groupId>gov.darpa.memex.imageCatalog</groupId>
+      <groupId>ai.mattmann.imagecat</groupId>
       <artifactId>oodt-extensions</artifactId>
       <version>${project.parent.version}</version>
       <type>jar</type>

--- a/pge/src/main/resources/bin/index-imagespace-fgbg/index-imagespace-fgbg.sh
+++ b/pge/src/main/resources/bin/index-imagespace-fgbg/index-imagespace-fgbg.sh
@@ -8,12 +8,12 @@ if [ -z "${IMAGE_SPACE_HOME:-}" ] && [ -n "${OODT_HOME:-}" ]; then
 fi
 
 if [ -z "${IMAGE_SPACE_HOME:-}" ]; then
-  echo "urn:memex:IndexImageSpaceFgBg: IMAGE_SPACE_HOME is unset; skip fg/bg CLIP"
+  echo "urn:imagecat:IndexImageSpaceFgBg: IMAGE_SPACE_HOME is unset; skip fg/bg CLIP"
   exit 0
 fi
 
 if [ ! -d "$IMAGE_SPACE_HOME/server" ]; then
-  echo "urn:memex:IndexImageSpaceFgBg: no server at $IMAGE_SPACE_HOME; skip fg/bg CLIP"
+  echo "urn:imagecat:IndexImageSpaceFgBg: no server at $IMAGE_SPACE_HOME; skip fg/bg CLIP"
   exit 0
 fi
 

--- a/pge/src/main/resources/bin/index-imagespace/index-imagespace.sh
+++ b/pge/src/main/resources/bin/index-imagespace/index-imagespace.sh
@@ -8,12 +8,12 @@ if [ -z "${IMAGE_SPACE_HOME:-}" ] && [ -n "${OODT_HOME:-}" ]; then
 fi
 
 if [ -z "${IMAGE_SPACE_HOME:-}" ]; then
-  echo "urn:memex:IndexImageSpace: IMAGE_SPACE_HOME is unset; skip CLIP rebuild"
+  echo "urn:imagecat:IndexImageSpace: IMAGE_SPACE_HOME is unset; skip CLIP rebuild"
   exit 0
 fi
 
 if [ ! -d "$IMAGE_SPACE_HOME/server" ]; then
-  echo "urn:memex:IndexImageSpace: no server at $IMAGE_SPACE_HOME; skip CLIP rebuild"
+  echo "urn:imagecat:IndexImageSpace: no server at $IMAGE_SPACE_HOME; skip CLIP rebuild"
   exit 0
 fi
 

--- a/pge/src/main/resources/bin/index-metadata-jaccard/index-metadata-jaccard.sh
+++ b/pge/src/main/resources/bin/index-metadata-jaccard/index-metadata-jaccard.sh
@@ -8,12 +8,12 @@ if [ -z "${IMAGE_SPACE_HOME:-}" ] && [ -n "${OODT_HOME:-}" ]; then
 fi
 
 if [ -z "${IMAGE_SPACE_HOME:-}" ]; then
-  echo "urn:memex:IndexMetadataJaccard: IMAGE_SPACE_HOME is unset; skip Jaccard"
+  echo "urn:imagecat:IndexMetadataJaccard: IMAGE_SPACE_HOME is unset; skip Jaccard"
   exit 0
 fi
 
 if [ ! -d "$IMAGE_SPACE_HOME/server" ]; then
-  echo "urn:memex:IndexMetadataJaccard: no server at $IMAGE_SPACE_HOME; skip Jaccard"
+  echo "urn:imagecat:IndexMetadataJaccard: no server at $IMAGE_SPACE_HOME; skip Jaccard"
   exit 0
 fi
 

--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
 --><project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
-  <groupId>gov.darpa.memex.imageCatalog</groupId>
+  <groupId>ai.mattmann.imagecat</groupId>
   <artifactId>oodt</artifactId>
   <name>ImageCat</name>
   <packaging>pom</packaging>

--- a/resmgr/pom.xml
+++ b/resmgr/pom.xml
@@ -21,7 +21,7 @@
 
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <groupId>gov.darpa.memex.imageCatalog</groupId>
+    <groupId>ai.mattmann.imagecat</groupId>
     <artifactId>oodt</artifactId>
     <version>0.1</version>
     <relativePath>../pom.xml</relativePath>
@@ -56,7 +56,7 @@
 
   <dependencies>
     <dependency>
-      <groupId>gov.darpa.memex.imageCatalog</groupId>
+      <groupId>ai.mattmann.imagecat</groupId>
       <artifactId>oodt-extensions</artifactId>
       <version>${project.parent.version}</version>
       <type>jar</type>

--- a/resmgr/src/main/resources/policy/node-to-queue-mapping.xml
+++ b/resmgr/src/main/resources/policy/node-to-queue-mapping.xml
@@ -16,56 +16,56 @@ License for the specific language governing permissions and limitations under
 the License.
 -->
 <cas:node-to-queue-mapping xmlns:cas="http://oodt.jpl.nasa.gov/1.0/cas">
-	<node id="memex-job1">
+	<node id="imagecat-job1">
 		<queues>
 			<queue name="high"/>
 			<queue name="quick"/>
 			<queue name="long"/>
 		</queues>
 	</node>	
-        <node id="memex-job2">
+        <node id="imagecat-job2">
                 <queues>
                         <queue name="high"/>
                         <queue name="quick"/>
                         <queue name="long"/>
                 </queues>
         </node>
-        <node id="memex-job3">
+        <node id="imagecat-job3">
                 <queues>
                         <queue name="high"/>
                         <queue name="quick"/>
                         <queue name="long"/>
                 </queues>
         </node>
-        <node id="memex-job4">
+        <node id="imagecat-job4">
                 <queues>
                         <queue name="high"/>
                         <queue name="quick"/>
                         <queue name="long"/>
                 </queues>
         </node>
-        <node id="memex-job5">
+        <node id="imagecat-job5">
                 <queues>
                         <queue name="high"/>
                         <queue name="quick"/>
                         <queue name="long"/>
                 </queues>
         </node>
-        <node id="memex-job6">
+        <node id="imagecat-job6">
                 <queues>
                         <queue name="high"/>
                         <queue name="quick"/>
                         <queue name="long"/>
                 </queues>
         </node>
-        <node id="memex-job7">
+        <node id="imagecat-job7">
                 <queues>
                         <queue name="high"/>
                         <queue name="quick"/>
                         <queue name="long"/>
                 </queues>
         </node>
-        <node id="memex-job8">
+        <node id="imagecat-job8">
                 <queues>
                         <queue name="high"/>
                         <queue name="quick"/>

--- a/resmgr/src/main/resources/policy/nodes.xml
+++ b/resmgr/src/main/resources/policy/nodes.xml
@@ -16,12 +16,12 @@ License for the specific language governing permissions and limitations under
 the License.
 -->
 <cas:resourcenodes xmlns:cas="http://oodt.jpl.nasa.gov/1.0/cas">
-	<node nodeId="memex-job1" ip="http://localhost:2001" capacity="2"/>
-        <node nodeId="memex-job2" ip="http://localhost:2002" capacity="2"/>
-        <node nodeId="memex-job3" ip="http://localhost:2003" capacity="2"/>
-        <node nodeId="memex-job4" ip="http://localhost:2004" capacity="2"/>
-        <node nodeId="memex-job5" ip="http://localhost:2005" capacity="2"/>
-        <node nodeId="memex-job6" ip="http://localhost:2006" capacity="2"/>
-        <node nodeId="memex-job7" ip="http://localhost:2007" capacity="2"/>
-        <node nodeId="memex-job8" ip="http://localhost:2008" capacity="2"/>
+	<node nodeId="imagecat-job1" ip="http://localhost:2001" capacity="2"/>
+        <node nodeId="imagecat-job2" ip="http://localhost:2002" capacity="2"/>
+        <node nodeId="imagecat-job3" ip="http://localhost:2003" capacity="2"/>
+        <node nodeId="imagecat-job4" ip="http://localhost:2004" capacity="2"/>
+        <node nodeId="imagecat-job5" ip="http://localhost:2005" capacity="2"/>
+        <node nodeId="imagecat-job6" ip="http://localhost:2006" capacity="2"/>
+        <node nodeId="imagecat-job7" ip="http://localhost:2007" capacity="2"/>
+        <node nodeId="imagecat-job8" ip="http://localhost:2008" capacity="2"/>
 </cas:resourcenodes>

--- a/solr/pom.xml
+++ b/solr/pom.xml
@@ -21,7 +21,7 @@
 
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <groupId>gov.darpa.memex.imageCatalog</groupId>
+    <groupId>ai.mattmann.imagecat</groupId>
     <artifactId>oodt</artifactId>
     <version>0.1</version>
     <relativePath>../pom.xml</relativePath>

--- a/webapps/fmprod/pom.xml
+++ b/webapps/fmprod/pom.xml
@@ -21,7 +21,7 @@
 
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <groupId>gov.darpa.memex.imageCatalog</groupId>
+    <groupId>ai.mattmann.imagecat</groupId>
     <artifactId>oodt</artifactId>
     <version>0.1</version>
     <relativePath>../../pom.xml</relativePath>

--- a/webapps/opsui/pom.xml
+++ b/webapps/opsui/pom.xml
@@ -21,7 +21,7 @@
 
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <groupId>gov.darpa.memex.imageCatalog</groupId>
+    <groupId>ai.mattmann.imagecat</groupId>
     <artifactId>oodt</artifactId>
     <version>0.1</version>
     <relativePath>../../pom.xml</relativePath>

--- a/webapps/pcs-services/pom.xml
+++ b/webapps/pcs-services/pom.xml
@@ -21,7 +21,7 @@
 
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <groupId>gov.darpa.memex.imageCatalog</groupId>
+    <groupId>ai.mattmann.imagecat</groupId>
     <artifactId>oodt</artifactId>
     <version>0.1</version>
     <relativePath>../../pom.xml</relativePath>

--- a/webapps/pom.xml
+++ b/webapps/pom.xml
@@ -17,7 +17,7 @@
 --><project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <groupId>gov.darpa.memex.imageCatalog</groupId>
+    <groupId>ai.mattmann.imagecat</groupId>
     <artifactId>oodt</artifactId>
     <version>0.1</version>
     <relativePath>../pom.xml</relativePath>

--- a/workflow/pom.xml
+++ b/workflow/pom.xml
@@ -21,7 +21,7 @@
 
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <groupId>gov.darpa.memex.imageCatalog</groupId>
+    <groupId>ai.mattmann.imagecat</groupId>
     <artifactId>oodt</artifactId>
     <version>0.1</version>
     <relativePath>../pom.xml</relativePath>
@@ -55,7 +55,7 @@
  
   <dependencies>
     <dependency>
-      <groupId>gov.darpa.memex.imageCatalog</groupId>
+      <groupId>ai.mattmann.imagecat</groupId>
       <artifactId>oodt-extensions</artifactId>
       <version>${project.parent.version}</version>
       <type>jar</type>

--- a/workflow/src/main/resources/policy/IngestInPlace.workflow.xml
+++ b/workflow/src/main/resources/policy/IngestInPlace.workflow.xml
@@ -1,11 +1,11 @@
-<cas:workflow xmlns:cas="http://oodt.jpl.nasa.gov/1.0/cas" name="IngestInPlace" id="urn:memex:IngestInPlaceWorkflow">
+<cas:workflow xmlns:cas="http://oodt.jpl.nasa.gov/1.0/cas" name="IngestInPlace" id="urn:imagecat:IngestInPlaceWorkflow">
  <tasks>
-   <task id="urn:memex:IngestInPlaceTask"/>
+   <task id="urn:imagecat:IngestInPlaceTask"/>
    <!-- After OCR/Tika land in Solr imagecat, score metadata Jaccard, then
         CLIP/FAISS, then fg/bg CLIP. Scripts no-op unless IMAGE_SPACE_HOME
         is set on the WM. -->
-   <task id="urn:memex:IndexMetadataJaccard"/>
-   <task id="urn:memex:IndexImageSpace"/>
-   <task id="urn:memex:IndexImageSpaceFgBg"/>
+   <task id="urn:imagecat:IndexMetadataJaccard"/>
+   <task id="urn:imagecat:IndexImageSpace"/>
+   <task id="urn:imagecat:IndexImageSpaceFgBg"/>
  </tasks>
 </cas:workflow>

--- a/workflow/src/main/resources/policy/events.xml
+++ b/workflow/src/main/resources/policy/events.xml
@@ -17,7 +17,7 @@
 <cas:workflowevents xmlns:cas="http://oodt.jpl.nasa.gov/1.0/cas">
 
   <event name="ChunkListIngest">
-     <workflow id="urn:memex:IngestInPlaceWorkflow"/>
+     <workflow id="urn:imagecat:IngestInPlaceWorkflow"/>
   </event>
 
 </cas:workflowevents>

--- a/workflow/src/main/resources/policy/tasks.xml
+++ b/workflow/src/main/resources/policy/tasks.xml
@@ -15,7 +15,7 @@
    limitations under the License.
   -->
 <cas:tasks xmlns:cas="http://oodt.jpl.nasa.gov/1.0/cas">
-  <task id="urn:memex:IngestInPlaceTask" name="IngestInPlace" class="org.apache.oodt.cas.pge.StdPGETaskInstance">
+  <task id="urn:imagecat:IngestInPlaceTask" name="IngestInPlace" class="org.apache.oodt.cas.pge.StdPGETaskInstance">
     <conditions/>
     <configuration>
       <property name="PGETask_Name" value="IngestInPlace"/>
@@ -32,7 +32,7 @@
     <requiredMetFields/>
   </task>
 
-  <task id="urn:memex:Chunker" name="Chunker" class="org.apache.oodt.cas.pge.StdPGETaskInstance">
+  <task id="urn:imagecat:Chunker" name="Chunker" class="org.apache.oodt.cas.pge.StdPGETaskInstance">
     <conditions/>
     <configuration>
       <property name="PGETask_Name" value="Chunker"/>
@@ -43,13 +43,12 @@
       <property name="PCS_MetFileExtension" value="met"/>
       <property name="PCS_ClientTransferServiceFactory" value="org.apache.oodt.cas.filemgr.datatransfer.LocalDataTransferFactory"/>
       <property name="PCS_ActionRepoFile" value="file:[CRAWLER_HOME]/policy/crawler-config.xml" envReplace="true"/>
-      <property name="CrawlTaskId" value="urn:memex:Crawl"/>
       <property name="ChunkSize" value="50000"/>
     </configuration>
     <requiredMetFields/>
   </task>
 
-  <task id="urn:memex:CheckFailedTask" name="CheckFailed" class="org.apache.oodt.cas.pge.StdPGETaskInstance">
+  <task id="urn:imagecat:CheckFailedTask" name="CheckFailed" class="org.apache.oodt.cas.pge.StdPGETaskInstance">
     <conditions/>
     <configuration>
       <property name="PGETask_Name" value="CheckFailed"/>
@@ -66,7 +65,7 @@
     <requiredMetFields/>
   </task>
 
-  <task id="urn:memex:OcrTask" name="OCR" class="org.apache.oodt.cas.pge.StdPGETaskInstance">
+  <task id="urn:imagecat:OcrTask" name="OCR" class="org.apache.oodt.cas.pge.StdPGETaskInstance">
     <conditions/>
     <configuration>
       <property name="PGETask_Name" value="OCR"/>
@@ -85,7 +84,7 @@
 
   <!-- After IngestInPlace OCR/Tika, score each Solr doc against the
        collection golden key/value sets (ETLlib Jaccard). -->
-  <task id="urn:memex:IndexMetadataJaccard" name="IndexMetadataJaccard" class="org.apache.oodt.cas.pge.StdPGETaskInstance">
+  <task id="urn:imagecat:IndexMetadataJaccard" name="IndexMetadataJaccard" class="org.apache.oodt.cas.pge.StdPGETaskInstance">
     <conditions/>
     <configuration>
       <property name="PGETask_Name" value="IndexMetadataJaccard"/>
@@ -103,7 +102,7 @@
 
   <!-- After IngestInPlace OCR, increment CLIP/FAISS for ImageSpace.
        Script no-ops unless IMAGE_SPACE_HOME is set on the workflow manager. -->
-  <task id="urn:memex:IndexImageSpace" name="IndexImageSpace" class="org.apache.oodt.cas.pge.StdPGETaskInstance">
+  <task id="urn:imagecat:IndexImageSpace" name="IndexImageSpace" class="org.apache.oodt.cas.pge.StdPGETaskInstance">
     <conditions/>
     <configuration>
       <property name="PGETask_Name" value="IndexImageSpace"/>
@@ -121,7 +120,7 @@
 
   <!-- After CLIP, increment foreground/background CLIP. No-op unless
        IMAGE_SPACE_HOME is set. Needs rembg in the ImageSpace embed venv. -->
-  <task id="urn:memex:IndexImageSpaceFgBg" name="IndexImageSpaceFgBg" class="org.apache.oodt.cas.pge.StdPGETaskInstance">
+  <task id="urn:imagecat:IndexImageSpaceFgBg" name="IndexImageSpaceFgBg" class="org.apache.oodt.cas.pge.StdPGETaskInstance">
     <conditions/>
     <configuration>
       <property name="PGETask_Name" value="IndexImageSpaceFgBg"/>


### PR DESCRIPTION
Identifiers only. Task **names** (`Chunker`, `IngestInPlace`, …) are unchanged. MEMEX inspiration credit stays in the README, wiki Home, and Tomcat splash.

| Was | Is |
| --- | --- |
| `urn:memex:Chunker` (and the rest of the task/workflow IDs) | `urn:imagecat:…` |
| `urn:memex:ChunkNum` (File Manager element) | `urn:imagecat:ChunkNum` |
| `memex-job1` … `memex-job8` | `imagecat-job1` … `imagecat-job8` |
| `gov.darpa.memex.imageCatalog` | `ai.mattmann.imagecat` |
| `CrawlTaskId` / `urn:memex:Crawl` | **removed** (no Crawl task was defined) |

Wiki How-to-Run / Interacting / Check-for-Failed already pushed with `urn:imagecat:`.

**Live unpack:** existing WM instance rows keep the old IDs. New jobs and `bin/chunker` need this tarball. The wiki filter is now `?workflow=urn:imagecat:IngestInPlaceWorkflow`.