### PR TITLE
Add README badges to match DRAT

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,12 @@
 ImageCatalog
 ============
+
+[![Build](https://github.com/chrismattmann/imagecat/actions/workflows/build.yml/badge.svg?branch=master)](https://github.com/chrismattmann/imagecat/actions/workflows/build.yml)
+[![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](http://www.apache.org/licenses/LICENSE-2.0)
+[![JDK](https://img.shields.io/badge/JDK-21-orange.svg)](https://adoptium.net/)
+[![Powered by Mnemosyne](https://img.shields.io/badge/powered%20by-Mnemosyne%201.11.0-6E4B8E.svg)](https://github.com/chrismattmann/mnemosyne)
+[![Wiki](https://img.shields.io/badge/wiki-github-informational.svg)](https://github.com/chrismattmann/imagecat/wiki)
+
 <img align="left" width="100" height="80" src="https://github.com/chrismattmann/imagecat/raw/master/ImageCat.png">
 
 This is a [RADiX](https://cwiki.apache.org/confluence/display/OODT/RADiX+Powered+By+OODT)


### PR DESCRIPTION
Same badge row as DRAT: Build, License, JDK 21, Powered by Mnemosyne 1.11.0.

ImageCat has no \`site.yml\` and no github.io site, so those two DRAT badges are skipped. Wiki is the repo homepage, so that is the last badge.